### PR TITLE
Warning re: enable_sst file when Interruptor is enabled during manual bootstrap process.

### DIFF
--- a/bootstrapping.html.md
+++ b/bootstrapping.html.md
@@ -292,10 +292,14 @@ Bootstrapping requires you to run commands from the [Ops Manager Director](http:
         #### <a id="restart-nodes"></a>Restart the remaining nodes ####
 
     1. Once the bootstrapped node is running, start the mariadb process on the remaining nodes via monit.
+         - If the Interruptor is enabled, you must additionally run this command before moving to the next step
+
+                $ touch /var/vcap/sys/run/galera-healthcheck/enable_sst
+
+        Start the mariadb process:
 
             $ monit start mariadb_ctrl
 
     1. Verify that the new nodes have successfully joined the cluster. The following command should output the total number of nodes in the cluster:
 
             mysql> SHOW STATUS LIKE 'wsrep_cluster_size';
-


### PR DESCRIPTION
For p-mysql 1.8.0