### PR TITLE
Update release notes to fix errors and omissions

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -8,15 +8,19 @@ owner: MySQL
 Release date: 23 September 2016
 
 - **Note:** Updated MariaDB to **10.1.17**.
-  The upgrade is automatic, and if deployed in HA configuration will not cause downtime for applications.
-  - Updated stemcell to 3232.19. This is a routine security upgrade that resolves low and medium vulnerabilities.
-– **Bug fix:** Introduced fix to replication canary to reduce the possibility of false positives.
+
+    The upgrade is automatic, and if deployed in HA configuration will not cause downtime for applications.
+
+- Updated stemcell to 3232.19. This is a routine security upgrade that resolves low and medium vulnerabilities.
+  - Updated Ruby and Rails software to additional resolve security vulnerabilities.
+- **Bug fix:** Introduced a fix to the replication canary which reduces the possibility of false positives.
 
 ## <a id="1-6-15"></a>1.6.15
 
 Release date: 23 September 2016
 
 - Updated stemcell to 3232.19. This is a routine security upgrade that resolves low and medium vulnerabilities.
+  - Updated Ruby and Rails software to additional resolve security vulnerabilities.
 
 Additional info can be found at https://pivotal.io/security
 


### PR DESCRIPTION
Sorry, it turns out the release notes we uploaded earlier had some formatting errors as well as omissions.

I ended up overwriting your changes, thank you for trying! I made sure the formatting worked well in `bundle exec bookbinder watch` before committing this time.

Have a great weekend!
