### PR TITLE
Account for updating mysql-monitoring-release to v6.

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -10,8 +10,8 @@ This is documentation for the MySQL for [Pivotal Cloud Foundry](https://network.
 Current MySQL for PCF Details
 <div style="line-height: 1; padding-left: 3em">
 
-- **Version**: 1.7.15
-- **Release Date**: 2016-10-05
+- **Version**: 1.7.16
+- **Release Date**: 2016-10-11
 - **Software component versions**: MariaDB 10.1.17, Galera 25.3.17
 - **Compatible Ops Manager Version(s)**: 1.5.x, 1.6.x, 1.7.x, 1.8.x
 - **Compatible Elastic Runtime Version(s)**: 1.5.x, 1.6.x, 1.7.x, 1.8.x
@@ -69,22 +69,22 @@ For more information, refer to the full [Product Version Matrix](http://docs.piv
 
 	<tr>
 		<td rowspan="2">1.6.1 - 1.6.17</td>
-		<td>Next 1.6.X release - 1.7.15</td>
+		<td>Next 1.6.X release - 1.7.16</td>
 	  <tr>
 		  <td>1.8.0-edge.1 - 1.8.0-edge.11</td>
 	  </tr>
 	</tr>
 
 	<tr>
-		<td rowspan="2">1.7.0 - 1.7.14</td>
-		<td>Next 1.7.X release - 1.7.15</td>
+		<td rowspan="2">1.7.0 - 1.7.15</td>
+		<td>Next 1.7.X release - 1.7.16</td>
 	  <tr>
 		  <td>1.8.0-edge.1 - 1.8.0-edge.11</td>
 	  </tr>
 	</tr>
 
 	<tr>
-		<td>1.7.15</td>
+		<td>1.7.16</td>
 		  <td>1.8.0-edge.1 - 1.8.0-edge.11</td>
 	</tr>
 </tr>

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -2,12 +2,18 @@
 title: Release Notes
 owner: MySQL
 ---
+
+## <a id="1-7-16"></a>1.7.16
+
+Release date: 11 October 2016
+
+- Includes stability and bug fixes.
+
 ## <a id="1-7-15"></a>1.7.15
 
 Release date: 5 October 2016
 
 - See below, same update as version 1.6.17
-
 
 ## <a id="1-6-17"></a>1.6.17
 


### PR DESCRIPTION
- Release notes say "stability and bug fixes" for now.