### PR TITLE
Updates for releases 1.6.20 and 1.7.20

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -10,8 +10,8 @@ This is documentation for the MySQL for [Pivotal Cloud Foundry](https://network.
 Current MySQL for PCF Details
 <div style="line-height: 1; padding-left: 3em">
 
-- **Version**: 1.7.19
-- **Release Date**: 2016-11-14
+- **Version**: 1.7.20
+- **Release Date**: 2016-12-07
 - **Software component versions**: MariaDB 10.1.18, Galera 25.3.17
 - **Compatible Ops Manager Version(s)**: 1.5.x, 1.6.x, 1.7.x, 1.8.x
 - **Compatible Elastic Runtime Version(s)**: 1.5.x, 1.6.x, 1.7.x, 1.8.x
@@ -59,34 +59,40 @@ For more information, refer to the full [Product Version Matrix](http://docs.piv
 
 
 <tr>
-	<th rowspan="9">1.4.x, 1.5.x<br>1.6.x, 1.7.x</th>
+	<th rowspan="5">1.4.x, 1.5.x<br>1.6.x, 1.7.x</th>
 	<td>1.4.0</td>
 	<td>1.5.0</td>
 
 	<tr>
 		<td>1.5.0</td>
-		<td>1.6.1 - 1.6.19</td>
+		<td>1.6.1 - 1.6.20</td>
 	</tr>
 
 	<tr>
-		<td rowspan="2">1.6.1 - 1.6.19</td>
-		<td>Next 1.6.X release - 1.7.19</td>
-	  <tr>
-		  <td>1.8.0-edge.1 - 1.8.0-edge.14</td>
-	  </tr>
+		<td rowspan="2">1.6.1 - 1.6.20</td>
+		<td>Next 1.6.X release - 1.6.20</td>
 	</tr>
 
 	<tr>
-		<td rowspan="2">1.7.0 - 1.7.18</td>
-		<td>Next 1.7.X release - 1.7.19</td>
-	  <tr>
-		  <td>1.8.0-edge.1 - 1.8.0-edge.14</td>
-	  </tr>
+		<td>1.7.0 - 1.7.20</td>
 	</tr>
 
 	<tr>
-		<td>1.7.18</td>
-		  <td>1.8.0-edge.1 - 1.8.0-edge.14</td>
+	  <td>1.7.0 - 1.7.19</td>
+		<td>Next 1.7.X release - 1.7.20</td>
+	</tr>
+
+	<tr>
+	  <th rowspan="3">1.8.x</th>
+		<td rowspan="2">1.6.1 - 1.6.20</td>
+		<td>Next 1.6.X release - 1.6.20</td>
+	</tr>
+
+	<tr>
+		<td>1.7.0 - 1.7.20</td>
+	<tr>
+	  <td>1.7.0 - 1.7.19</td>
+		<td>Next 1.7.X release - 1.7.20</td>
 	</tr>
 </tr>
 

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -2,9 +2,24 @@
 title: Release Notes
 owner: MySQL
 ---
+
+## <a id="1.7.20"></a>1.7.20
+
+Release Date: 07 December 2016
+
+- See below, same update as version 1.6.20
+
+## <a id="1-6-19"></a>1.6.19
+
+Release Date: 07 December 2016
+
+- Updated stemcell to 3263.12 to resolve the following:
+  - [USN-3151-2](https://www.ubuntu.com/usn/usn-3151-2/)
+
+
 ## <a id="1.7.19"></a>1.7.19
 
-Release Date 14 November 2016
+Release Date: 14 November 2016
 
 - Updated stemcell to 3233.4 to address standard security updates.
 - Updated MariaDB to version 10.1.18 to resolve a variety of unspecified security vulnerabilities.
@@ -12,14 +27,14 @@ Release Date 14 November 2016
 
 ## <a id="1.7.18"></a>1.7.18
 
-Release Date 26 October 2016
+Release Date: 26 October 2016
 
 - Updated stemcell to 3233.3, same update as version 1.6.19.
 - **Security:** Update the service broker to prevent logging of service credentials.
 
 ## <a id="1-6-19"></a>1.6.19
 
-Release Date 21 October 2016
+Release Date: 21 October 2016
 
 - Updated MariaDB to version **10.1.18** to resolve a variety of unspecified security vulnerabilities.
 - Updated stemcell to 3233.3. This is a security upgrade that resolves the following:


### PR DESCRIPTION
- Accounts for high CVE USN-3151-2
- Also re-worked the table in Product snapshot to account for PCF 1.8.0
- Fixed some missing punctuation (colons) in release notes.