### PR TITLE
Add Known Issue around broken errands

### DIFF
--- a/bootstrapping.html.md
+++ b/bootstrapping.html.md
@@ -297,6 +297,8 @@ Bootstrapping requires you to run commands from the [Ops Manager Director](http:
 
             $ monit start mariadb_ctrl
 
+        If the node is prevented from starting by the Interruptor, use the [manual steps](monitoring-mysql.html#manual-rejoin) to force an SST.
+
     1. Verify that the new nodes have successfully joined the cluster. The following command outputs the total number of nodes in the cluster:
 
             mysql> SHOW STATUS LIKE 'wsrep_cluster_size';

--- a/bootstrapping.html.md
+++ b/bootstrapping.html.md
@@ -292,9 +292,6 @@ Bootstrapping requires you to run commands from the [Ops Manager Director](http:
         #### <a id="restart-nodes"></a>Restart the remaining nodes ####
 
     1. After the bootstrapped node is running, start the mariadb process on the remaining nodes via monit.
-         - If the Interruptor is enabled, run this command:
-
-                $ touch /var/vcap/sys/run/galera-healthcheck/enable_sst
 
         Start the mariadb process:
 

--- a/known-issues.html.md.erb
+++ b/known-issues.html.md.erb
@@ -3,6 +3,24 @@ title: Known Issues
 owner: MySQL
 ---
 
+## <a id="broken-errand-templates"></a> Bootstrap and Rejoin-Unsafe Errand Issue
+
+There is an issue in versions 1.8.0 - 1.8.2 in which the `bootstrap` and `rejoin-unsafe` errands fail with an error like this:
+
+    Error 100: Unable to render jobs for instance group 'rejoin-unsafe'. Errors are:
+       - Unable to render templates for job 'rejoin-unsafe'. Errors are:
+         - Error filling in template 'config.yml.erb' (line 8: Can't find link 'arbitrator')
+
+This is a bug in those releases. It will be addressed in a coming release. In the meanwhile, it may be necessary to perform these steps manually:
+
+  - For `boostrap`, you must use the [manual bootstrap](bootstrapping.html#manual-bootstrap) instructions to restore access to the cluster.
+  - For `rejoin-unsafe`, you must follow these steps:
+    1. Log into the node which has tripped the [interruptor](monitoring-mysql.html#interruptor) and become root.
+    1. monit stop mariadb_ctrl
+    1. rm -rf /var/vcap/store/mysql
+    1. /var/vcap/jobs/mysql/bin/pre-start
+    1. monit start mariadb_ctrl
+
 ## <a id="compile-fails"></a> Compile fails in environments that do not have access to the Internet ##
 
 In MySQL for Pivotal Cloud Foundry (PCF) `1.8.0-Edge.5` and `1.8.0-Edge.6`, there is a regression which will cause the compile stage to fail while installing the tile on environments that do not have access to the Internet. We regret the error.

--- a/monitoring-mysql.html.md.erb
+++ b/monitoring-mysql.html.md.erb
@@ -7,7 +7,7 @@ This document describes how to use the Replication Canary and Interruptor to mon
 
 ## <a id="repcanary"></a>Replication Canary
 
-MySQL for Pivotal Cloud Foundry (PCF) is a clustered solution that uses replication to  provide benefits such as quick failover and rolling upgrades. This is more complex than a single node system with no replication. MySQL for PCF includes a Replication Canary to help with the increased complexity. The Replication Canary is a long-running monitor that validates that replication is working within the MySQL cluster. 
+MySQL for Pivotal Cloud Foundry (PCF) is a clustered solution that uses replication to  provide benefits such as quick failover and rolling upgrades. This is more complex than a single node system with no replication. MySQL for PCF includes a Replication Canary to help with the increased complexity. The Replication Canary is a long-running monitor that validates that replication is working within the MySQL cluster.
 
 ### <a id="overview-canary"></a>How it Works
 
@@ -120,7 +120,7 @@ WSREP_SST: [ERROR] #############################################################
 
 ### <a id="force-rejoin"></a>Force a Node to Rejoin the Cluster
 
-In general, if the Interruptor has activated but the Replication Canary has not triggered, it is safe for the node to rejoin the cluster.
+In general, if the Interruptor has activated but the Replication Canary has not triggered, it is safe for the node to rejoin the cluster. You can check the health of the remaining nodes in the cluster by following the same [instructions](scaling-down.html#check-health) used before scaling from clustered to single-node mode.
 
 <p class='note'><strong>Note</strong>: This topic requires you to run commands from the <a href="http://docs.pivotal.io/pivotalcf/customizing/index.html">Ops Manager Director</a> using the BOSH CLI. Refer to the <a href="http://docs.pivotal.io/pivotalcf/customizing/trouble-advanced.html#prepare">Advanced Troubleshooting with the BOSH CLI</a> topic for more information.</p>
 
@@ -141,6 +141,15 @@ In general, if the Interruptor has activated but the Replication Canary has not 
 
     Errand `rejoin-unsafe' completed successfully (exit code 0)
     </pre>
+
+#### <a id="manual-rejoin"></a> Manual Rejoin
+
+- If the `rejoin-unsafe` errand is not able to cause a node to join the cluster, follow these steps to bypass the Interruptor manually.
+  1. Log into each node which has tripped the [interruptor](monitoring-mysql.html#interruptor) and become root.
+  1. monit stop mariadb_ctrl
+  1. rm -rf /var/vcap/store/mysql
+  1. /var/vcap/jobs/mysql/bin/pre-start
+  1. monit start mariadb_ctrl
 
 ### Disable the Interruptor
 


### PR DESCRIPTION
p-mysql versions 1.8.0 through 1.8.2 have a bug in which the `rejoin-unsafe` and `bootstrap` errands do not work. Update Known Issues so that Support can refer to these docs when asking customers to upgrade to a coming release.
