### PR TITLE
Account for v1.7.29, which includes changes for IPSec.

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -10,8 +10,8 @@ This is documentation for the MySQL for [Pivotal Cloud Foundry](https://network.
 Current MySQL for PCF Details
 <div style="line-height: 1; padding-left: 3em">
 
-- **Version**: v1.7.28
-- **Release Date**: 2017 April 27
+- **Version**: v1.7.29
+- **Release Date**: 2017 May 19
 - **Software component versions**: MariaDB v10.1.18, Galera v25.3.17
 - **Compatible Ops Manager Version(s)**: Versions 1.6.x through 1.10.x
 - **Compatible Elastic Runtime Version(s)**: Versions 1.6.x through 1.10.x
@@ -75,12 +75,12 @@ For more information, see the full [Product Compatibility Matrix](http://docs.pi
 	</tr>
 
 	<tr>
-		<td>v1.7.0 – v1.7.28</td>
+		<td>v1.7.0 – v1.7.29</td>
 	</tr>
 
 	<tr>
-	  <td>v1.7.0 – v1.7.27<sup>*</sup></td>
-		<td>Next v1.7.x release – v1.7.28</td>
+	  <td>v1.7.0 – v1.7.28<sup>*</sup></td>
+		<td>Next v1.7.x release – v1.7.29</td>
 	</tr>
 
 </tr>

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -5,6 +5,14 @@ owner: MySQL
 
 <html class="list-style-none"></html>
 
+## <a id="1-7-29"></a>v1.7.29
+
+Release Date: May 19, 2017
+
+- We've made two changes to address issues with MySQL for PCF when the [IPSec add-on](https://docs.pivotal.io/addon-ipsec/) is also installed.
+  - **Bug fix:** While installing MySQL for PCF with IPSec installed, the product may fail to deploy. This may be due to an issue where the default probe timeout is too long while running under IPSec, and should be reduced. Version 1.7.29 of MySQL for PCF allows you to reduce the New Cluster Probe Timeout in the MySQL server configuration page. Read more about this in the Read more about this in the [options and features](https://docs.pivotal.io/p-mysql/1-8/index.html#options_and_features) topic.
+  - **Bug fix:** We also made a small change in the way that MySQL nodes shut down, which should better allow nodes to leave the cluster gracefully while IPSec is installed.
+
 ## <a id="1-7-28"></a>v1.7.28
 
 Release Date: April 27, 2017


### PR DESCRIPTION
  Slight quirk: Since we don't enumerate configuration settings for the
  1.7 tile in the index, I've linked to the same docuemntation which
  will be in the 1.8 documentation. I'd rather do this, than overhaul
  the 1.7 documentation to include exhaustive configuration
  documentation. After all, the UI and configuration are the same.