### PR TITLE
Update for release 1.7.30, which requires stemcell 3312.28

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -10,8 +10,8 @@ This is documentation for the MySQL for [Pivotal Cloud Foundry](https://network.
 Current MySQL for PCF Details
 <div style="line-height: 1; padding-left: 3em">
 
-- **Version**: v1.7.29
-- **Release Date**: 2017 May 19
+- **Version**: v1.7.30
+- **Release Date**: June 2, 2017
 - **Software component versions**: MariaDB v10.1.18, Galera v25.3.17
 - **Compatible Ops Manager Version(s)**: Versions 1.6.x through 1.10.x
 - **Compatible Elastic Runtime Version(s)**: Versions 1.6.x through 1.10.x
@@ -75,12 +75,12 @@ For more information, see the full [Product Compatibility Matrix](http://docs.pi
 	</tr>
 
 	<tr>
-		<td>v1.7.0 – v1.7.29</td>
+		<td>v1.7.0 – v1.7.30</td>
 	</tr>
 
 	<tr>
-	  <td>v1.7.0 – v1.7.28<sup>*</sup></td>
-		<td>Next v1.7.x release – v1.7.29</td>
+	  <td>v1.7.0 – v1.7.29<sup>*</sup></td>
+		<td>Next v1.7.x release – v1.7.30</td>
 	</tr>
 
 </tr>

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -5,6 +5,15 @@ owner: MySQL
 
 <html class="list-style-none"></html>
 
+## <a id="1-7-30"></a>v1.7.30
+
+Release Date: June 2, 2017
+
+- Updated stemcell to 3312.28. This is a security upgrade that resolves the following:
+  - [USN-3291-3](http://www.ubuntu.com/usn/USN-3291-3/)
+
+Additional information can be found at https://pivotal.io/security
+
 ## <a id="1-7-29"></a>v1.7.29
 
 Release Date: May 19, 2017


### PR DESCRIPTION
Not sure why this is marked as, "cant automatically merge," perhaps I did something wrong when trying to update from upstream?
