### PR TITLE
Update for release 1.8.9, which requires stemcell 3312.28

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -14,11 +14,11 @@ The following table provides version and version-support information about MySQL
     <th>Details</th>
     <tr>
         <td>Version</td>
-        <td>v1.8.8</td>
+        <td>v1.8.9</td>
     </tr>
     <tr>
         <td>Release date</td>
-        <td>May 19, 2017</td>
+        <td>June 2, 2017</td>
     </tr>
     <tr>
         <td>Software component version</td>
@@ -63,15 +63,15 @@ For more information, refer to the full [Product Compatibility Matrix](https://d
       <td rowspan="3">v1.6.1 – v1.6.25</td><td>Next v1.6.x release – v1.6.26</td>
 		</tr>
 		<tr>
-		  <td>v1.7.0 – v1.7.29</td>
+		  <td>v1.7.0 – v1.7.30</td>
 		</tr>
 		<tr>
-			<td>v1.8.8</td>
+			<td>v1.8.9</td>
 		</tr>
 		<tr>
-			<td rowspan=2>v1.7.0 – v1.7.28</td><td>Next v1.7.x release – v1.7.29</td>
-	                                   <tr><td>v1.8.8</td></tr>
-    <tr><td>v1.8.0 – v1.8.7</td><td>v1.8.8</td></tr>
+			<td rowspan=2>v1.7.0 – v1.7.29</td><td>Next v1.7.x release – v1.7.30</td>
+	                                   <tr><td>v1.8.9</td></tr>
+    <tr><td>v1.8.0 – v1.8.8</td><td>v1.8.9</td></tr>
 	</tr>
 
 </table>

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -14,6 +14,15 @@ owner: MySQL
      }
 </style>
 
+## <a id="1-8-9"></a>1.8.9
+
+Release Date: June 2, 2017
+
+- Updated stemcell to 3312.28. This is a security upgrade that resolves the following:
+  - [USN-3291-3](http://www.ubuntu.com/usn/USN-3291-3/)
+
+Additional information can be found at https://pivotal.io/security
+
 ## <a id="1-8-8"></a>1.8.8
 
 Release Date: May 19, 2017


### PR DESCRIPTION
Not sure why this is marked as, "cant automatically merge," perhaps I did something wrong when trying to update from upstream?
