### PR TITLE
v1.9.5 also offers GCP and Azure backup targets

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -30,7 +30,7 @@ Release Date: June 22, 2017
 
 - New backup storage options:
 
-    MySQL for PCF 1.9 can now store backup artifacts on Google Cloud Storage or Azure Blob Storage.
+    MySQL for PCF v1.9 can now store backup artifacts on Google Cloud Storage or Azure Blob Storage.
 
 - Updated stemcell to 3312.29. This security upgrade resolves the following:
   + [USN-3334-1](http://www.ubuntu.com/usn/USN-3334-1/).

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -28,9 +28,13 @@ Release Date: June 22, 2017
 
     If you don't want syslogging, select **Disable syslog** and click **Save**.
 
+- New backup storage options:
+
+    MySQL for PCF 1.9 can now store backup artifacts on Google Cloud Storage or Azure Blob Storage.
+
 - Updated stemcell to 3312.29. This security upgrade resolves the following:
   + [USN-3334-1](http://www.ubuntu.com/usn/USN-3334-1/).
-  
+
     For more information, see [pivotal.io/security](https://pivotal.io/security).
 
 ## <a id="1-9-4"></a>v1.9.4


### PR DESCRIPTION
Whoops, these software changes snuck out in a CVE release. That's fine.

Expect to see a PR soon that updates the documentation for these new backup targets.
