### PR TITLE
Updates for 1.10.3

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -29,11 +29,11 @@ The following table provides version and version-support information about MySQL
     <th>Details</th>
     <tr>
         <td>Version</td>
-        <td>v1.10.2</td>
+        <td>v1.10.3</td>
     </tr>
     <tr>
         <td>Release date</td>
-        <td>August 21, 2017</td>
+        <td>September 14, 2017</td>
     </tr>
     <tr>
         <td>Software component version</td>

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -14,7 +14,7 @@ owner: MySQL
      }
 </style>
 
-<p class="note"><strong>Note</strong>: MySQL for PCF v1.10 requires PCF v1.10 and later.</p>
+<p class="note"><strong>Note</strong>: MySQL for PCF v1.10 requires PCF v1.10 or later.</p>
 
 ## <a id="1-10-3"></a>v1.10.3
 

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -16,6 +16,13 @@ owner: MySQL
 
 <p class="note"><strong>Note</strong>: MySQL for PCF v1.10 requires PCF v1.10 and later.</p>
 
+## <a id="1-10-3"></a>v1.10.3
+
+Release Date: September 14, 2017
+
+- Re-names package dependencies to avoid installation conflicts.
+- Updates stemcell to 3363.35, which addresses a minor logrotate issue.
+
 ## <a id="1-10-2"></a>v1.10.2
 
 Release Date: August 21, 2017


### PR DESCRIPTION
Updates 1.10.3, which re-names dependencies and upgrades to stemcell 3363.35.