### PR TITLE
p-mysql 1.9.12

### DIFF
--- a/configuring.html.md.erb
+++ b/configuring.html.md.erb
@@ -101,6 +101,12 @@ For more information about how MySQL for PCF is configured, see the [architectur
 
     There is special logic to detect if a starting node is the first node of a new installation, or if it is part of an existing cluster. Part of this logic is to probe if the other nodes of the cluster have already been deployed. In cases of high latency, this timeout period may be too long. When these probes take too long to respond, it's possible that the **MySQL Start Timeout** might fail the deployment. To account for this, either increase the **MySQL Start Timeout** or lower the **New Cluster Probe Timeout** so that a new node doesn't spend too long performing this test.
 
+- <a id="allow-table-locks"></a>**Allow Table Locks**
+
+    Default: Enabled
+
+    When enabled, clients will be able to acquire table locks on the node processing the transaction. Enabled for backwards compatibility, it is recommended disabling this for all new deployments, as table locks are not replicated across cluster nodes.
+
 - **Enable Large Indices**
 
     Default: Enabled

--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -29,11 +29,11 @@ The following table provides version and version-support information about MySQL
     <th>Details</th>
     <tr>
         <td>Version</td>
-        <td>v1.9.11</td>
+        <td>v1.9.12</td>
     </tr>
     <tr>
         <td>Release date</td>
-        <td>September 21, 2017</td>
+        <td>September 29, 2017</td>
     </tr>
     <tr>
         <td>Software component version</td>

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -6,6 +6,16 @@ owner: MySQL
 <p class="note"><strong>Note</strong>: MySQL for PCF v1.9 is certified to work with PCF v1.9 and v1.10.
    For PCF v1.11, upgrade to MySQL for PCF v1.10.</p>
 
+## <a id="1-9-12"></a>v1.9.12
+
+Release Date: September 29, 2017
+
+- **New:** Now provides a checkbox where the Operator can configure table locking behavior. See the [allow table locks](configuring.html#allow-table-locks) section of the configuration page for more information.
+- We've bumped the default size of the backup VMs from 1 GB RAM / 2 CPUs to 4GB RAM / 4 CPUs. You can customize this default in the Resource Configuration pane.
+- **Bug fix:** Pre-start phase will now log warnings, rather than time out when `mysqld` takes time to start or stop.
+- **Security:** Updates to rubygems 2.6.6 to address [CVE-2017-0902](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-0902).
+
+
 ## <a id="1-9-11"></a>v1.9.11
 
 Release Date: September 21, 2017


### PR DESCRIPTION
[#151076204]

Update to account for release 1.9.12, which includes cf-mysql
v36.4-v36.6, and several UI tweaks.