### PR TITLE
1.9 docs updates (EOL 1.9)

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -3,7 +3,9 @@ title: Release Notes
 owner: MySQL
 ---
 
-<p class="note"><strong>Note</strong>: MySQL for PCF v1.9 is certified to work with PCF v1.9 and v1.10.
+<p class="note"><strong>Note:</strong> **This is the last planned release of MySQL for PCF 1.9. The support period for 1.9 has expired. To stay up-to-date with the latest software and security updates, please plan to upgrade to MySQL for PCF version 1.10 or greater.
+
+<p class="note"><strong>Note:</strong> MySQL for PCF v1.9 is certified to work with PCF v1.9 and v1.10.
    For PCF v1.11, upgrade to MySQL for PCF v1.10.</p>
 
 ## <a id="1.9.18"></a>v1.9.18
@@ -11,7 +13,7 @@ owner: MySQL
 Release Date: February 7, 2018
 
 - **Bug fix:** `mysql-diag` should fail quickly when VMs in the cluster are not available.
-- **Bug fix:** Replication canary causes high CPU spikes because it overwrites 
+- **Bug fix:** Replication canary causes high memory usage spikes because it overwrites
 rather than appends to logs files.
 
 ## <a id="1-9-17"></a>v1.9.17

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -3,7 +3,10 @@ title: Release Notes
 owner: MySQL
 ---
 
-<p class="note"><strong>Note:</strong> **This is the last planned release of MySQL for PCF 1.9. The support period for 1.9 has expired. To stay up-to-date with the latest software and security updates, please plan to upgrade to MySQL for PCF version 1.10 or greater.
+<p class="note"><strong>Note:</strong> **This is the last planned release of MySQL for PCF v1.9.
+   The support period for 1.9 has expired.
+   To stay up-to-date with the latest software and security updates,
+   upgrade to MySQL for PCF v1.10 or later.
 
 <p class="note"><strong>Note:</strong> MySQL for PCF v1.9 is certified to work with PCF v1.9 and v1.10.
    For PCF v1.11, upgrade to MySQL for PCF v1.10.</p>


### PR DESCRIPTION
Add tile retirement notice. Also, repcanary fix addresses memory spikes, not CPU.