### PR TITLE
mysql-backups v2.2.0 is actually backups v2.3.0

### DIFF
--- a/mysql-components-release-notes.html.md.erb
+++ b/mysql-components-release-notes.html.md.erb
@@ -7,9 +7,13 @@ owner: MySQL
 For release notes for MySQL for PCF v1.10, see <a href="release-notes.html">Release Notes</a>.
 </p>
 
-## <a id="backups-2.2.0"></a>mysql-backups v2.2.0
+## <a id="backups-2.3.0"></a>mysql-backups v2.3.0
 
 - **Changed:** streaming-mysql-backup-tool should use mysql defaults file rather than rely on /etc/mysql/my.cnf [[#156407009](https://www.pivotaltracker.com/story/show/156407009)]
+
+## <a id="backups-2.2.0"></a>mysql-backups v2.2.0
+
+  - **Do not use**
 
 ## <a id="monitoring-8.16.0"></a>mysql-monitoring v8.16.0
 


### PR DESCRIPTION
[#156623296] 

Unfortunately, v2.2.0 was eaten by robots. The software has been
released as v2.3.0 instead.