### PR TITLE
Add mysql-agent port 8443 to list of network rules

### DIFF
--- a/about.html.md.erb
+++ b/about.html.md.erb
@@ -82,7 +82,12 @@ Regardless of the specific network layout, the operator must ensure network rule
 		<td><strong>ODB</strong></td>
 		<td><strong>MySQL service instances</strong>
 		</td>
-		<td>3306</td>
+		<td>	
+			<ul>
+				<li>3306</li>
+				<li>8443</li>
+			</ul>
+		</td>
 		<td>One-way</td>
 		<td>This connection is for administrative tasks. Avoid opening general use, app-specific ports for this connection.</td>
 	</tr>


### PR DESCRIPTION
Leaving port 3306 in the list for now, we should remove it when we remove support for the old binding workflow.

[#156146477]