### PR TITLE
deleted confusing note

### DIFF
--- a/prepare-tls.html.md.erb
+++ b/prepare-tls.html.md.erb
@@ -7,8 +7,6 @@ owner: MySQL
 
 This topic describes how to provide an existing CA certificate to BOSH CredHub and how to generate a new CA
 certificate with BOSH CredHub, if you do not already have one.
-<p class="note"><strong>Note</strong>: If you want to enable TLS for MySQL for Pivotal Cloud Foundry (PCF),
-	you must perform the procedures in this topic <strong>before</strong> installing and configuring the tile.</p>
 
 <p class="note warning"><strong>WARNING</strong>: This procedure involves restarting all of the VMs in your PCF deployment in order to apply a CA certificate. The operation can take a long time to complete.</p>
 


### PR DESCRIPTION
The note mentions that you need to follow these TLS steps _before_ configuring/installing the tile, which is totally confusing, since you can definitely do this after you've installed the tile. 

I propose just removing it.