### PR TITLE
update 2.4 docs to mention BOSH DNS Healthcheck port

### DIFF
--- a/about.html.md.erb
+++ b/about.html.md.erb
@@ -119,4 +119,12 @@ Regardless of the specific network layout, the operator must ensure network rule
 		<td>This port is needed if secure service instance credentials are enabled.
                     For information, see <a href="install-config.html#security">Configure Security</a>.</td>
 	</tr>
+	<tr>
+		<td><strong>PAS</strong></td>
+		<td><strong>MySQL Service Instances</strong>
+		</td>
+		<td>8853</td>
+		<td>One-way</td>
+		<td>This port is for DNS to do health checks against services instances.</td>
+	</tr>
 </table>

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -18,6 +18,12 @@ For instructions on verifying the stemcell, see <a href="./install-config.html#s
 To download the Xenial stemcell from Pivotal Network, go to <a href="https://network.pivotal.io/products/stemcells-ubuntu-xenial"> Stemcells for PCF (Ubuntu Xenial)</a>.
 </p>
 
+<p class="note breaking"><strong>Breaking Change: </strong>New service bindings created on MySQL for PCF v2.4.0 replaces
+  IP addresses with DNS hostnames. In order for apps bound to Leader-Follower service instances to use DNS hostnames,
+  you must modify your network rules. For instructions on how to configure your network rules, see 
+  <a href="https://docs.pivotal.io/p-mysql/2-4/upgrade.html">Upgrading MySQL for PCF</a>.
+</p>
+
 ## <a id="244"></a>v2.4.4
 
 **Release Date:**  February 5, 2019

--- a/upgrade.html.md.erb
+++ b/upgrade.html.md.erb
@@ -23,6 +23,14 @@ you must update the add-on definition to include the Xenial stemcell before you 
 + ClamAV for PCF Add-on. For update instructions, see [Updating ClamAV Add-on for PCF to Run with Xenial Stemcells](https://docs.pivotal.io/addon-antivirus/updating-for-xenial.html).
 + IPsec for PCF Add-on. For update instructions, see [Updating IPsec Add-on for PCF to Run with Xenial Stemcells](https://docs.pivotal.io/addon-ipsec/updating-for-xenial.html).
 
+## <a id="change-networking"></a>Update Networking Rules
+
+MySQL for PCF v2.4.0 and later implements DNS hostnames in service bindings, which removes the need to rebind apps when 
+doing Leader-Follower failovers. In order for apps to connect to a Leader-Follower service instance over DNS, you must
+update your Networking rules to allow the DNS server in the PAS network to talk to MySQL service instances.
+
+1. Update your networking rules so that it matches the table in 
+   <a href="https://docs.pivotal.io/p-mysql/2-4/about.html#rules">Required Networking Rules for On-Demand Services</a>.
 
 ## <a id="upgrade-service"></a>Upgrade MySQL for PCF
 


### PR DESCRIPTION
i noticed that this was missing in docs, and caused quite a few customers to run into issues where they can't connect to their L-F instance because BOSH DNS wasn't configured correctly. i'm happy to clarify any of the changes i've made. thanks!