### PR TITLE
smoke-tests uses the PAS apps domain

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -30,6 +30,16 @@ go to <a href="https://network.pivotal.io/products/stemcells-ubuntu-xenial"> Ste
   For more information, see <a href="./upgrade.html#change-networking">Update Networking Rules</a>.
 </p>
 
+## <a id="246"></a>v2.4.6
+
+**Release Date:**  Jun 13, 2019
+  
+### Resolved Issue
+
+This release fixes a bug, so that:
+
+* Smoke-tests consistently uses the PAS apps domain
+ 
 ## <a id="245"></a>v2.4.5
 
 **Release Date:**  April 5, 2019


### PR DESCRIPTION
This is for a Salesforce ticket filed by Penske