### PR TITLE
Updated metrics documentation:

### DIFF
--- a/monitoring/kpis-metrics/_all-kpis.html.erb
+++ b/monitoring/kpis-metrics/_all-kpis.html.erb
@@ -109,7 +109,7 @@
     
     {
       metric: <<~DESC,
-        /net/max_connections<br><br>
+        /variables/max_connections<br><br>
         /p.mysql/net/max_used_connections
       DESC
        

--- a/monitoring/kpis-metrics/_ha-metrics.html.erb
+++ b/monitoring/kpis-metrics/_ha-metrics.html.erb
@@ -9,7 +9,7 @@
       },
       
       {
-        source: 'galera/local\_recv\_queue',
+        source: 'galera/wsrep_local\_recv\_queue',
         description: 'The current length of the local receive queue, in messages.',
         unit: 'count',
         tag: 'queue'

--- a/monitoring/kpis-metrics/_mysql-metrics.html.erb
+++ b/monitoring/kpis-metrics/_mysql-metrics.html.erb
@@ -250,13 +250,6 @@
       },
 
       {
-        source: 'innodb/buffer\_pool\_utilization',
-        description: 'The utilization of the InnoDB Buffer Pool, as a unit interval (0 to 1).',
-        unit: 'float',
-        tag: 'buffer-pool-util'
-      },
-
-      {
         source: 'performance/cpu\_utilization\_percent',
         description:'The percent of the CPU in use by all processes on the MySQL node.',
         unit: 'percent',


### PR DESCRIPTION
Updating docs in response to the question asked by the docs team. There were indeed some discrepencies that need fixing. Note that there are several other metrics which are in the OSS docs and not in the Pivotal docs, on purpose, because those are legacy support for v1 and older OSS products. 
Those are:
`/performance/cpu_time`,
`/broker/disk_allocated_service_plans`,
and `/innodb/buffer_pool_utilization`

The changes in this PR are:
- rename from net/max_connections -> variables/max_connections to
reflect the emiited metric

- updated galera name to reflect emitted name, because it was incorrect.

- removed innodb/buffer_pool_utilization because it is not emitted in
v2. (It's only emitted by mariaDB, used exclusively in the v1 tile)

[#166907996]

Signed-off-by: Caroline Taymor <ctaymor@pivotal.io>