### PR TITLE
Rotating CA port for bulk-regenerate, fix authorization header

### DIFF
--- a/rotating-ca.html.md.erb
+++ b/rotating-ca.html.md.erb
@@ -205,12 +205,12 @@ To regenerate your internal certificates and redeploy your service instances, fo
 1. To regenerate all certificates signed by the old CA certificate, run the following:
 
     ```
-    curl "https://BOSH-DIRECTOR/api/v1/bulk-regenerate"" -X POST \
+    curl "https://BOSH-DIRECTOR:8844/api/v1/bulk-regenerate"" -X POST \
     -d '{ "signed_by": "/services/tls_ca" }'\
-    -H "authorization: bearer $(credhub --token)"\
+    -H "authorization: $(credhub --token)"\
     -H 'content-type: application/json'
     ```
-    Where `BOSH-DIRECTOR` is the IP address of the BOSH Director VM.
+    Where `BOSH-DIRECTOR` is the IP address of the BOSH Director VM. In this case, you're talking to the BOSH Director's [Credhub to perform `bulk-regenerate`](https://credhub-api.cfapps.io/version/master/#_bulk_regenerate_credentials), but the BOSH Director's IP is used because the Director's Credhub is co-located on the same VM, just on a different port.
 
 1. To redeploy all service instances with the new certificates, run the following:
 

--- a/rotating-ca.html.md.erb
+++ b/rotating-ca.html.md.erb
@@ -206,8 +206,8 @@ To regenerate your internal certificates and redeploy your service instances, fo
 
     ```
     curl "https://BOSH-DIRECTOR:8844/api/v1/bulk-regenerate"" -X POST \
-    -d '{ "signed_by": "/services/tls_ca" }'\
-    -H "authorization: $(credhub --token)"\
+    -d '{ "signed_by": "/services/tls_ca" }' \
+    -H "authorization: $(credhub --token)" \
     -H 'content-type: application/json'
     ```
     Where `BOSH-DIRECTOR` is the IP address of the BOSH Director VM. In this case, you're talking to the BOSH Director's [Credhub to perform `bulk-regenerate`](https://credhub-api.cfapps.io/version/master/#_bulk_regenerate_credentials), but the BOSH Director's IP is used because the Director's Credhub is co-located on the same VM, just on a different port.


### PR DESCRIPTION
Ran into some confusion with the doc on rotating-ca, wanted to give a little touchup that might help others:

`bulk-generate` is an API endpoint against credhub, not of the BOSH director itself. If you leave the port number off, you get `connection refused`'s against the Director instead of Credhub. 

Adds port number and sentence describing why the `BOSH-DIRECTOR` IP is used even though it's not hitting the director itself, it's hitting the co-located credhub.

Removes the "bearer" section of authorization header, because `credhub --token` includes "Bearer" prefix by default

Disclaimer: I'm by no means a technical writer, please don't merge this in directly, I leave it entirely to professionals to consider/review or re-implement in a separate PR (and possibly backport if appropriate?), feel free to close whenever, etc.

Thanks for your time 👍 