### PR TITLE
Fix call to cf mysql-tools version

### DIFF
--- a/migrate-data.html.md.erb
+++ b/migrate-data.html.md.erb
@@ -144,7 +144,7 @@ Do the following to install the `mysql-tools` cf CLI plugin:
 2. Ensure the plugin has installed successfully by running the following command:
 
     ```
-    cf mysql-tools --version
+    cf mysql-tools version
     ```
 3. You can run the following command to view plugin usage details:
 


### PR DESCRIPTION
The original doc had this:
`cf mysql-tools --version` which is incorrect.  It should be `cf mysql-tools version`