### PR TITLE
Update example default-collation to have underscores

### DIFF
--- a/change-default.html.md.erb
+++ b/change-default.html.md.erb
@@ -297,7 +297,7 @@ For more specific use cases, you can customize the following parameters:
   <tr>
     <td><code>default-collation</code></td>
     <td>String</td>
-    <td><code>utf8-general-ci</code></td>
+    <td><code>utf8_general_ci</code></td>
     <td>The <code>default-collation</code> changes based on the <code>default-charset</code>.
       To set the <code>default-collation</code>, first set the <code>default-charset</code>.
       For a list of available and default collations,


### PR DESCRIPTION
When using the documentation as a reference for what value to set for the default-collation if the value `utf8-general-ci` is copied and pasted into a configuration block it will fail with the following exception:

```
Server error, status code: 502, error code: 10001, message: Service broker error: The 'default-collation' parameter can only be a lowercase alphanumeric string with underscores and no other special characters
```

It might be more usable for the value in the documentation be set to `utf8_general_ci`.  I am not sure if other references in the doc should also be updated since the value that is required should have underscored and not dashes.