### PR TITLE
Rename 2.7.3 to 2.7.4

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -14,7 +14,7 @@ version, upgrade to the latest v2.6.x version before upgrading to the latest v2.
 
 For product versions and upgrade paths, see the [Product Compatibility Matrix](https://docs.pivotal.io/resources/product-compatibility-matrix.pdf).
 
-## <a id="2-7-3"></a> v2.7.3
+## <a id="2-7-4"></a> v2.7.4
 
 **Release Date: January 6, 2020**
 
@@ -49,6 +49,8 @@ This release has the following fixes:
 This release has the following issue:
 
 <%= partial "../../p-mysql/partials/mysql/disable-plan-ki" %>
+
+## <a id="2-7-3"></a> v2.7.3 - Skipped
 
 ## <a id="2-7-2"></a> v2.7.2
 


### PR DESCRIPTION
We mistakenly labeled this release notes for 2.7.3. They are actually related to 2.7.4.