### PR TITLE
Remove OM/TAS 2.6 from 2.8 compatibility

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -50,11 +50,11 @@ The following table provides version and version-support information about <%= v
 </tr>
 <tr>
   <td>Compatible <%= vars.ops_manager %> versions</td>
-  <td>2.10, 2.9, 2.8, 2.7, and 2.6</td>
+  <td>2.10, 2.9, 2.8, and 2.7</td>
 </tr>
 <tr>
   <td>Compatible <%= vars.app_runtime_full %> (<%= vars.app_runtime_abbr %>) versions</td>
-  <td>2.10, 2.9, 2.8, 2.7, and 2.6</td>
+  <td>2.10, 2.9, 2.8, and 2.7</td>
 </tr>
 <tr>
   <td>IaaS support</td>


### PR DESCRIPTION
We would like to focus on OM/TAS 2.7+.

Which other branches should this be merged with (if any)? No, this change is just for MySQL 2.8
