### PR TITLE
Remove "beta" from multi-site replication per #175502214

### DIFF
--- a/about-multi-site.html.md.erb
+++ b/about-multi-site.html.md.erb
@@ -5,10 +5,6 @@ owner: MySQL
 
 <strong><%= modified_date %></strong>
 
-<!-- The below partial is in https://github.com/pivotal-cf/docs-partials -->
-
-<%= partial vars.path_to_partials + '/mysql/multi_site_beta' %>
-
 This topic describes how the <%= vars.single_leader_plan_lc %> topology works in
 <%= vars.product_full %> and contains information to help users decide whether to use
 the <%= vars.single_leader_plan %> plan.

--- a/about.html.md.erb
+++ b/about.html.md.erb
@@ -213,10 +213,6 @@ To ensure that connections are open, see the table below:
 
 <h3> <a id='multi-site-ports'></a> Required Networking Rules for <%= vars.single_leader_plan %> </h3>
 
-<!-- The below partial is in https://github.com/pivotal-cf/docs-partials -->
-
-<%= partial '../../p-mysql/partials/mysql/multi_site_beta' %>
-
 If you are using <%= vars.single_leader_plan_lc %>, the operator must set network rules for
 both foundations in addition to the networking rules required for <%= vars.product_short %>.
 

--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -31,8 +31,6 @@ that the service meets user expectations for a general-use relational database.
 +  <%= vars.single_leader_plan %>. For more information,
     see [About <%= vars.single_leader_plan %>](./about-multi-site.html).
 
-    <%= partial vars.path_to_partials + "/mysql/multi_site_beta" %>
-
 ## <a id='snapshot'></a> Product Snapshot
 
 The following table provides version and version-support information about <%= vars.product_short %>.

--- a/install-config.html.md.erb
+++ b/install-config.html.md.erb
@@ -274,7 +274,7 @@ For each plan that you want to use in your deployment:
       <button class="tablinks active" onclick="openDocs(event, 'tab1')">Single Node</button>
       <button class="tablinks" onclick="openDocs(event, 'tab2')">Leader-Follower</button>
       <button class="tablinks" onclick="openDocs(event, 'tab3')">HA Cluster</button>
-      <button class="tablinks" onclick="openDocs(event, 'tab4')"> <%= vars.single_leader_plan %> [BETA]</button>
+      <button class="tablinks" onclick="openDocs(event, 'tab4')"> <%= vars.single_leader_plan %> </button>
     </div>
 
 

--- a/multi-site-trigger-failover.html.md.erb
+++ b/multi-site-trigger-failover.html.md.erb
@@ -7,8 +7,6 @@ owner: MySQL
 The topic describes how to trigger a failover and switchover
  when using a <%= vars.single_leader_plan %> plan.
 
-<%= partial '../../p-mysql/partials/mysql/multi_site_beta' %>
-
 ##<a id='overview'></a> Overview
 
 You can trigger a failover or switchover to redirect traffic to a secondary foundation.

--- a/prepare-multi-site.html.md.erb
+++ b/prepare-multi-site.html.md.erb
@@ -5,10 +5,6 @@ owner: MySQL
 
 <strong><%= modified_date %></strong>
 
-<!-- The below partial is in https://github.com/pivotal-cf/docs-partials -->
-
-<%= partial '../../p-mysql/partials/mysql/multi_site_beta' %>
-
 This topic provides instructions to operators about how to prepare foundations for
 <%= vars.single_leader_plan_lc %> using <%= vars.product_full %>.
 

--- a/use-multi-site.html.md.erb
+++ b/use-multi-site.html.md.erb
@@ -4,8 +4,6 @@ owner: MySQL
 ---
 <strong><%= modified_date %></strong>
 
-<%= partial '../../p-mysql/partials/mysql/multi_site_beta' %>
-
 This topic provides instructions for developers using the <%= vars.product_full %> for replication
 across multiple foundations or data centers.
 


### PR DESCRIPTION
Signed-off-by: Kim Bassett <kbassett@pivotal.io>
Signed-off-by: Andrew Garner <agarner@pivotal.io>

Remove references to multi-site being in Beta.
(We have not removed partials elements which surface in the docs, but those are likely safe to remove. We feel docs team is better equipped for that call.)

Which other branches should this be merged with (if any)?
2.8 2.9 2.10
