### PR TITLE
Improve Multi-Site Replication failover procedure

### DIFF
--- a/multi-site-trigger-failover.html.md.erb
+++ b/multi-site-trigger-failover.html.md.erb
@@ -216,7 +216,7 @@ To make the leader read-only and promote the follower to leader in the secondary
 
     ```
     cf update-service PRIMARY-INSTANCE \
-      -c '{"initiate-failover":"make-leader-read-only"}
+      -c '{"initiate-failover":"make-leader-read-only"}'
     ```
 
     For example:
@@ -319,7 +319,7 @@ To reconfigure replication for the service instances:
 
     ```
     cf create-service-key PRIMARY-INSTANCE SERVICE-KEY \
-      -c '{"replication-request": "host-info"}
+      -c '{"replication-request": "host-info"}'
     ```
     Where:
     + `PRIMARY-INSTANCE` is the name of the follower service instance in the primary foundation.
@@ -377,7 +377,7 @@ To reconfigure replication for the service instances:
     + `HOST-INFO` is the output you recorded in step above.
 
     For example:
-    <pre class="terminal">$ cf update-service secondary-node -c {"replication":{ \
+    <pre class="terminal">$ cf update-service secondary-node -c '{"replication":{ \
       "peer-info":{ \
           "hostname": "primary.bosh", \
           "ip": "10.0.18.12", \
@@ -386,7 +386,7 @@ To reconfigure replication for the service instances:
         },\
       "role": "leader" \
       } \
-    }<br>
+    }'<br>
   Updating service instance secondary-node as admin...
   OK</pre>
 1.  Watch the progress of the service instance update by running:
@@ -402,7 +402,7 @@ To reconfigure replication for the service instances:
 
     ```
     cf create-service-key SECONDARY-INSTANCE SERVICE-KEY-NAME \
-      -c '{"replication-request": "credentials"}
+      -c '{"replication-request": "credentials"}'
     ```
     Where:
     + `SECONDARY-INSTANCE` is the name of the service instance in the secondary foundation.
@@ -464,7 +464,7 @@ To reconfigure replication for the service instances:
     + `CREDENTIALS` is the output you recorded in the step above.
 
     For example:
-    <pre class="terminal">$ cf update-service primary-node -c {"replication": { \
+    <pre class="terminal">$ cf update-service primary-node -c '{"replication": { \
         "credentials": { \
           "password": "a22aaa2a2a2aaaaa", \
           "username": "6bf07ae455a14064a9073cec8696366c" \
@@ -477,7 +477,7 @@ To reconfigure replication for the service instances:
         }, \
         "role": "follower" \
       } \
-    }<br>
+    }'<br>
   Updating service instance primary-node as admin...
   OK</pre>
 

--- a/multi-site-trigger-failover.html.md.erb
+++ b/multi-site-trigger-failover.html.md.erb
@@ -94,6 +94,8 @@ To trigger a failover:
 
 1. [Promote the Follower](#promote-failover)
 1. [Delete the Former Leader](#clean-up)
+1. [Create a Follower](#create-follower)
+1. [Re-Configure <%= vars.single_leader_plan %>](#restore-follower)
 
 
 ### <a id='promote-failover'></a> Promote the Follower
@@ -161,10 +163,10 @@ To promote the follower service instance to leader:
 1. Reconfigure your global DNS load balancer to direct all traffic to apps in your secondary foundation.
 See [Configure Your GLB](https://docs.pivotal.io/platform/plan/global-dns-lb.html#configure-glb).
 
-###<a id='clean-up'></a> Delete the Former Leader
+###<a id='clean-up'></a> Delete or Purge the Former Leader
 
 When you do a failover, the leader service instance cannot be manually recovered. After you promote the follower
-service instance to leader, you should delete the former leader service instance. Otherwise,
+service instance to leader, you should remove the former leader service instance. Otherwise,
 the service instance could recover in read-write mode.
 
 To delete the former leader service instance:
@@ -176,11 +178,34 @@ To delete the former leader service instance:
     ```
     Where `PRIMARY-API-URL` is the API endpoint for the primary foundation.
 
-1. Remove all bindings and service keys from the former leader service instance by
-    doing the procedure in [Unbind an App from a Service Instance](./use.html#unbind).
+1. Remove all app bindings in [Unbind an App from a Service Instance](./use.html#unbind).
 
-1. Delete the former leader service instance by doing the procedure in
-    [Delete a Service Instance](./use.html#delete).
+1. The service instance needs to be removed. This depends on whether the VM has been lost or not.
+
+   + **If the VM is lost**:
+
+     Purge the service instance by doing the procedure in [Purge a Service Instance](./use.html#purge).
+
+     <p class="note"><strong>Note:</strong>
+       If the foundation is lost, you should purge the service instance **after** following the steps to recover the
+       foundation's cloud controller database in
+       [Restoring Deployments from Backup with BBR](https://docs.pivotal.io/ops-manager/2-10/install/backup-restore/restore-pcf-bbr.html)
+     </p>
+
+   + **If the VM is not lost**:
+
+     Delete the service keys from the former leader service instance and then the service instance by
+     doing the procedure in [Delete a Service Instance](./use.html#delete).
+
+###<a id='create-follower'></a> Create a Follower
+
+In order to re-configure <%= vars.single_leader_plan %> between two instances, a new follower without any data must be created
+in the primary foundation. See the procedure in [Create a Service Instance](./use.html#create)
+
+###<a id='restore-follower'></a> Re-Configure <%= vars.single_leader_plan %>
+
+The follower in the primary foundation needs to catch up to the newly promoted leader in the secondary
+foundation. This is achieved by following the steps in [Reconfigure <%= vars.single_leader_plan %>](#configure)
 
 ##<a id='switchover'></a> Trigger a Switchover
 

--- a/use.html.md.erb
+++ b/use.html.md.erb
@@ -470,3 +470,29 @@ that the instance no longer exists:
     ```
     watch cf service SERVICE-INSTANCE
     ```
+
+### <a id="purge"></a>Purge a Service Instance
+
+If the service instance VM is lost, then the service instance cannot be removed. The cf CLI
+allows a service instance to be purged from the cloud controller database.
+
+To purge a service instance:
+
+1. Run the following command:
+
+    ```
+    cf purge-service-instance SERVICE-INSTANCE
+    ```
+
+    Where `SERVICE-INSTANCE` is the name of the service instance to purge.
+    <br><br>
+    For example:
+
+    <pre class="terminal">
+    $ cf purge-service-instance my-instance<br>
+    WARNING: This operation assumes that the service broker responsible for this service instance is no longer available or is not responding with a 200 or 410, and the service instance has been deleted, leaving orphan records in Cloud Foundry's database. All knowledge of the service instance will be removed from Cloud Foundry, including service bindings and service keys.
+
+    Really purge service instance test from Cloud Foundry?> y
+    Purging service my-instance...
+    OK
+    </pre>


### PR DESCRIPTION
Which other branches should this be merged with (if any)? 2.10, 2.9, and 2.8

This PR improves the Multi-Site replication failover procedure to be more detailed on how to properly recover from a disaster incident that necessitates a failover.

I linked to the BBR restore procedure in OpsManager 2.10. I'm not sure if there's a better way to link to that.

Happy to discuss before or after this is merged to clarify anything.
