### PR TITLE
Started the release notes for 2.10.6.

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -23,8 +23,9 @@ MySQL patch and VMware releasing Tanzu SQL with MySQL for VMs containing that pa
 
 This release includes the following security fix:
 
-+ **[CVE-2021-44228](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2021-44228) / [CVE 2021-45046](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45046) - Remote code injection in Log4j2:**
-  Bumped log4j to 2.16.0 as message lookup substitution behavior has been disabled by default.
++ **[CVE-2021-44228](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2021-44228) / [CVE 2021-45046](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45046) / [CVE 2021-45105](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105) - Remote code injection in Log4j2:**
+
+  Bumped log4j to v2.17.0 in the sample spring app used in the smoke tests errand.
 
 ### Resolved Issues
 

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -23,8 +23,8 @@ MySQL patch and VMware releasing Tanzu SQL with MySQL for VMs containing that pa
 
 This release includes the following security fix:
 
-+ **CVE-2021-44228 - Remote code injection in Log4j2:**
-  Bumped log4j to 2.15.0 as message lookup substitution behavior has been disabled by default. 
++ **[CVE-2021-44228](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2021-44228) / [CVE 2021-45046](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45046) - Remote code injection in Log4j2:**
+  Bumped log4j to 2.16.0 as message lookup substitution behavior has been disabled by default.
 
 ### Resolved Issues
 

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -13,6 +13,50 @@ latest available patch for the next minor.
 Because VMware uses the Percona Distribution for MySQL, expect a time lag between Oracle releasing a
 MySQL patch and VMware releasing Tanzu SQL with MySQL for VMs containing that patch.
 
+## <a id="2-10-6"></a> v2.10.6
+
+**Release Date: MONTH DD, YYYY**
+
+### Features
+
+### Security Fixes
+
+This release includes the following security fix:
+
++ **CVE-2021-44228 - Remote code injection in Log4j2:**
+  Bumped log4j to 2.15.0 as message lookup substitution behavior has been disabled by default. 
+
+### Resolved Issues
+
+### Known Issues
+
+This release has the following issues:
+
+<%= partial vars.path_to_partials + "/mysql/disable-plan-ki" %>
+<%= partial vars.path_to_partials + "/mysql/ki-adbr-blob-store-base-url" %>
+
+### Compatibility
+
+The following components are compatible with this release:
+
+<table border="1" class="nice">
+
+  <tr>
+    <th>Component</th>
+    <th>Version</th>
+  </tr>
+
+  <tr><td>Stemcell</td><td></td></tr>
+  <tr><td>Percona Server</td><td></td></tr>
+  <tr><td>Percona XtraDB Cluster</td><td></td></tr>
+  <tr><td>Percona XtraBackup</td><td></td></tr>
+  <tr><td>mysql-backup-release</td><td></td></tr>
+  <tr><td>mysql-monitoring-release</td><td></td></tr>
+  <tr><td>pxc-release</td><td></td></tr>
+
+</table>
+
+&#42; _Components marked with an asterisk have been updated_
 ## <a id="2-10-5"></a> v2.10.5
 
 **Release Date: MONTH DD, YYYY**


### PR DESCRIPTION
Added notes for the log4j bump to address CVE-2021-44228

[180604549]

Co-authored-by: Colin Shield <cshield@vmware.com>
Co-authored-by: Kevin Markwardt <kmarkwardt@vmware.com>

Which other branches should this be merged with (if any)?
