### PR TITLE
Update compatibility table in v2.10.6 release notes

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -49,13 +49,13 @@ The following components are compatible with this release:
     <th>Version</th>
   </tr>
 
-  <tr><td>Stemcell</td><td></td></tr>
-  <tr><td>Percona Server</td><td></td></tr>
-  <tr><td>Percona XtraDB Cluster</td><td></td></tr>
-  <tr><td>Percona XtraBackup</td><td></td></tr>
-  <tr><td>mysql-backup-release</td><td></td></tr>
-  <tr><td>mysql-monitoring-release</td><td></td></tr>
-  <tr><td>pxc-release</td><td></td></tr>
+  <tr><td>Stemcell</td><td>621.196+</td></tr>
+  <tr><td>Percona Server</td><td>5.7.35-38</td></tr>
+  <tr><td>Percona XtraDB Cluster</td><td>5.7.35-31.53</td></tr>
+  <tr><td>Percona XtraBackup</td><td>2.4.24</td></tr>
+  <tr><td>mysql-backup-release</td><td>2.18.0</td></tr>
+  <tr><td>mysql-monitoring-release</td><td>9.15.0</td></tr>
+  <tr><td>pxc-release</td><td>0.41.0</td></tr>
 
 </table>
 


### PR DESCRIPTION
I noticed the [release notes in the `master` branch](https://github.com/pivotal-cf/docs-mysql/blob/53de56ceb7a45ddf1c634da0db410eee9502c38d/release-notes.html.md.erb#L111-L117) did not have an updated compatibility table.

This PR is based off the 2.10 branch.   Let us know if we should resubmit.