### PR TITLE
Fixup for correct stemcell version

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -42,7 +42,7 @@ The following components are compatible with this release:
     <th>Version</th>
   </tr>
 
-  <tr><td>Stemcell</td><td>621.196+</td></tr>
+  <tr><td>Stemcell</td><td>621.261+</td></tr>
   <tr><td>Percona Server</td><td>5.7.37-40*</td></tr>
   <tr><td>Percona XtraDB Cluster</td><td>5.7.37-31.57*</td></tr>
   <tr><td>Percona XtraBackup</td><td>2.4.26*</td></tr>


### PR DESCRIPTION
Confirmed in both publish-release-canditate:
https://dedicated-mysql.ci.cf-app.com/teams/main/pipelines/tile-2.10/jobs/publish-release-candidate/builds/6

and publish-final-tile:
https://dedicated-mysql.ci.cf-app.com/teams/main/pipelines/tile-2.10/jobs/publish-final-tile/builds/26

Authored-by: Ryan Wittrup <rwittrup@vmware.com>

Which other branches should this be merged with (if any)?
