### PR TITLE
Adds release notes for 2.10.10

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -22,7 +22,7 @@ MySQL patch and VMware releasing <%= vars.product_full %> containing that patch.
 This release includes the following changes:
 
 + Increases the default value for max-connections to 5000. For details refer to [About MySQL Server Defaults](./server-defaults.html).
-+ This release adds support for the optional parameter `wsrep_applier_threads`. For details refer to [](./change-default.html#wsrep_applier_threads).
++ This release exposes the optional parameter `wsrep_applier_threads`, sets the default to 4, and allows users to customize it. For details refer to [](./change-default.html#wsrep_applier_threads).
 + pxc-release bump to golang 1.19.3
 + dedicated-mysql-release bump to golang 1.19.2
 + dedicated-mysql-adapter bump to golang 1.19.3

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -21,7 +21,7 @@ MySQL patch and VMware releasing <%= vars.product_full %> containing that patch.
 
 This release includes the following changes:
 
-+ Increases the default value for max-connections from 750 to 5000. For details refer to [About MySQL Server Defaults](./server-defaults.html).
++ Increases the default value for max-connections to 5000. For details refer to [About MySQL Server Defaults](./server-defaults.html).
 + This release adds support for the optional parameter `wsrep_applier_threads`. For details refer to [](./change-default.html#wsrep_applier_threads).
 + pxc-release bump to golang 1.19.3
 + dedicated-mysql-release bump to golang 1.19.2

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -13,6 +13,54 @@ and then upgrade to the latest patch available for the next minor.
 Because VMware uses the Percona Distribution for MySQL, expect a time lag between Oracle releasing a
 MySQL patch and VMware releasing <%= vars.product_full %> containing that patch.
 
+## <a id="2-10-10"></a> v2.10.10
+
+**Release Date: Nov 29, 2022**
+
+### Features
+
+This release includes the following new features:
+
++ It is important to install this version of Percona Server (5.7.39-42) before upgrading to version 3.x of the MySQL tile. Version 3.x of the MySQL tile will upgrade Percona Server to 8.x from 5.7.x. Upgrading to version 5.7.39-42 of Percona Server now ensures that you can complete the upgrade to Percona Server 8.x with minimal downtime.
+
++ Increases default value for max-connections, <a href="server-defaults.html">About MySQL Server Defaults.</a>
++ pxc-release bump to golang 1.19.3
++ dedicated-mysql-release bump to golang 1.19.2
++ dedicated-mysql-adapter bump to golang 1.19.3
++ mysql-monitoring bump to golang 1.19.2
++ adbr bump to golang 1.19.3, bug fix for error users may have seen when backup up database with a large number of tables
+
+### Known Issues
+
+This release has the following known issues:
+
+<%= partial vars.path_to_partials + '/mysql/disable-plan-ki' %>
++ **In TAS 2.13, the MySQL tile metrics are not available when using the `cf tail` command.** The metrics are still available to other external services such as Healthwatch.
++ **Issue with Hitachi Content Platform HS3:** Ensure that you configure the storage device to use a *flat space*, not a *structured space*.
+
+### Compatibility
+
+The following components are compatible with this release:
+
+<table border="1" class="nice">
+
+  <tr>
+    <th>Component</th>
+    <th>Version</th>
+  </tr>
+
+  <tr><td>Stemcell</td><td>621.330+</td></tr>
+  <tr><td>Percona Server</td><td>5.7.40-43*</td></tr>
+  <tr><td>Percona XtraDB Cluster</td><td>5.7.39-31.61</td></tr>
+  <tr><td>Percona XtraBackup</td><td>2.4.26</td></tr>
+  <tr><td>mysql-backup-release</td><td>2.22.0*</td></tr>
+  <tr><td>mysql-monitoring-release</td><td>9.22.0*</td></tr>
+  <tr><td>pxc-release</td><td>0.48.0*</td></tr>
+
+</table>
+
+&#42; _Components marked with an asterisk have been updated_
+
 ## <a id="2-10-9"></a> v2.10.9
 
 **Release Date: October 11, 2022**

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -22,7 +22,7 @@ MySQL patch and VMware releasing <%= vars.product_full %> containing that patch.
 This release includes the following changes:
 
 + Increases the default value for max-connections to 5000. For details refer to [About MySQL Server Defaults](./server-defaults.html).
-+ This release exposes the optional parameter `wsrep_applier_threads`. The default is set to 4, users can customize it. For details refer to [Changing Defaults Using Arbitrary Parameters](./change-default.html#wsrep_applier_threads).
++ This release exposes the optional parameter `wsrep_applier_threads`. The default is set to 4, and users can customize it. For details refer to [Changing Defaults Using Arbitrary Parameters](./change-default.html#wsrep_applier_threads).
 + pxc-release bump to golang 1.19.3
 + dedicated-mysql-release bump to golang 1.19.2
 + dedicated-mysql-adapter bump to golang 1.19.3

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -22,7 +22,7 @@ MySQL patch and VMware releasing <%= vars.product_full %> containing that patch.
 This release includes the following changes:
 
 + Increases the default value for max-connections to 5000. For details refer to [About MySQL Server Defaults](./server-defaults.html).
-+ This release exposes the optional parameter `wsrep_applier_threads`, sets the default to 4, and allows users to customize it. For details refer to [](./change-default.html#wsrep_applier_threads).
++ This release exposes the optional parameter `wsrep_applier_threads`. The default is set to 4, users can customize it. For details refer to [Changing Defaults Using Arbitrary Parameters](./change-default.html#wsrep_applier_threads).
 + pxc-release bump to golang 1.19.3
 + dedicated-mysql-release bump to golang 1.19.2
 + dedicated-mysql-adapter bump to golang 1.19.3

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -15,13 +15,14 @@ MySQL patch and VMware releasing <%= vars.product_full %> containing that patch.
 
 ## <a id="2-10-10"></a> v2.10.10
 
-**Release Date: Nov 29, 2022**
+**Release Date: Dec 5th, 2022**
 
-### Features
+### Changes
 
-This release includes the following new features:
+This release includes the following changes:
 
-+ Increases default value for max-connections, <a href="server-defaults.html">About MySQL Server Defaults.</a>
++ Increases the default value for max-connections from 750 to 5000. For details refer to [About MySQL Server Defaults](./server-defaults.html).
++ This release adds support for the optional parameter `wsrep_applier_threads`. For details refer to [](./change-default.html#wsrep_applier_threads).
 + pxc-release bump to golang 1.19.3
 + dedicated-mysql-release bump to golang 1.19.2
 + dedicated-mysql-adapter bump to golang 1.19.3

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -21,8 +21,6 @@ MySQL patch and VMware releasing <%= vars.product_full %> containing that patch.
 
 This release includes the following new features:
 
-+ It is important to install this version of Percona Server (5.7.39-42) before upgrading to version 3.x of the MySQL tile. Version 3.x of the MySQL tile will upgrade Percona Server to 8.x from 5.7.x. Upgrading to version 5.7.39-42 of Percona Server now ensures that you can complete the upgrade to Percona Server 8.x with minimal downtime.
-
 + Increases default value for max-connections, <a href="server-defaults.html">About MySQL Server Defaults.</a>
 + pxc-release bump to golang 1.19.3
 + dedicated-mysql-release bump to golang 1.19.2
@@ -69,7 +67,7 @@ The following components are compatible with this release:
 
 This release includes the following new features:
 
-+ It is important to install this version of Percona Server (5.7.39-42) before upgrading to version 3.x of the MySQL tile. Version 3.x of the MySQL tile will upgrade Percona Server to 8.x from 5.7.x. Upgrading to version 5.7.39-42 of Percona Server now ensures that you can complete the upgrade to Percona Server 8.x with minimal downtime.
++ Reduces downtime when upgrading to future versions of the MySQL for VMs tile
 + pxc-release bump to golang 1.19.1
 + dedicated-mysql-adapter bump to golang 1.19.1
 + mysql-monitoring uses bpm


### PR DESCRIPTION
This shouldn't be completed until two related PR's are also approved and merged:
https://github.com/pivotal-cf/docs-mysql/pull/437 - max-connections
https://github.com/pivotal-cf/docs-mysql/pull/436 - applier threads

[#183528811](https://www.pivotaltracker.com/story/show/183528811)

Co-authored-by: Ryan Wittrup <rwittrup@vmware.com>
Co-authored-by: Kevin Markwardt <kmarkwardt@vmware.com>

Which other branches should this be merged with (if any)?
