### PR TITLE
PLAN VM EXTENSIONS: Add table row documenting new GUI feature

### DIFF
--- a/install-config.html.md.erb
+++ b/install-config.html.md.erb
@@ -355,6 +355,14 @@ For each plan that you want to use in your deployment:
         <td> BOSH deploys your service instances to the selected AZs.
           If more than one AZ is selected, BOSH randomizes which AZ to place each VM. <br>
         </td></tr>
+    <tr><td><strong>Plan VM Extensions</strong></td>
+        <td>Specify a comma-separated list of BOSH cloud-config-supported VM extensions you want to
+          apply to service instances created under this plan. <br>
+          You can manage VM Extensions in Ops Manager or through the OM CLI.
+          For more information, see <a href="https://docs.pivotal.io/ops-manager/install/custom-vm-extensions.html#create-vm-extension">
+          Create or Update a VM Extension</a> or <a href="https://github.com/pivotal-cf/om/blob/main/docs/create-vm-extension/README.md">om create-vm-extension</a>
+          in GitHub. <br>
+        </td></tr>
   </table>
 1. Click **Save**.
 

--- a/install-config.html.md.erb
+++ b/install-config.html.md.erb
@@ -356,12 +356,14 @@ For each plan that you want to use in your deployment:
           If more than one AZ is selected, BOSH randomizes which AZ to place each VM. <br>
         </td></tr>
     <tr><td><strong>Plan VM Extensions</strong></td>
-        <td>Specify a comma-separated list of BOSH cloud-config-supported VM extensions you want to
+        <td>Specify a comma-separated list of supported VM Extensions you want to
           apply to service instances created under this plan. <br>
           You can manage VM Extensions in Ops Manager or through the OM CLI.
-          For more information, see <a href="https://docs.pivotal.io/ops-manager/install/custom-vm-extensions.html#create-vm-extension">
+          For more information, see <a href="https://docs.pivotal.io/ops-manager/install/custom-vm-extensions.html">
           Create or Update a VM Extension</a> or <a href="https://github.com/pivotal-cf/om/blob/main/docs/create-vm-extension/README.md">om create-vm-extension</a>
           in GitHub. <br>
+          <strong>NOTE:</strong> If you specify an extension that is not supported by Ops Manager (not present in the BOSH cloud
+          config), then instance creation attempts will fail. <br>
         </td></tr>
   </table>
 1. Click **Save**.


### PR DESCRIPTION
This commit should accompany new screenshots of each plan's config page, including the newest bottom-most field "Plan VM Extensions" (after "MySQL Availability Zone(s)"). Those screenshots are NOT a part of this commit; docs team should create new screenshots per their doc standards.

[#184443880](https://www.pivotaltracker.com/story/show/184443880)

Which other branches should this be merged with (if any)?
A: None. This is only for the upcoming MySQL Tile 3.0 release (& subsequent releases)
