### PR TITLE
Update release-notes.html.md.erb

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -32,6 +32,8 @@ This release includes the following changes:
 This release includes the following breaking changes:
 
 + The `enable_tls` property has been renamed to `enforce_client_tls`.
++ Ubuntu Jammy stemcells require TLS v1.2 or above. 
++ If you plan to use MySQL 8.0 service instances, please note that only TLS v1.3 is supported 
 
 ### Compatibility
 


### PR DESCRIPTION
Added note for Jammy requiring TLS 1.2 and MySQL 8 requiring TLS 1.3

Which other branches should this be merged with (if any)?
