### PR TITLE
add note about named time zone support in 3.1.0

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -13,6 +13,14 @@ and then upgrade to the latest patch available for the next minor.
 Because VMware uses the Percona Distribution for MySQL, expect a time lag between Oracle releasing a
 MySQL patch and VMware releasing <%= vars.product_full %> containing that patch.
 
+## <a id="3-1-0"></a> v3.1.0
+
+### New Features
+
++ Time Zone information is now loaded into the MySQL system database to support named time zones
+
+  See the [MySQL Server Time Zone Support](https://dev.mysql.com/doc/refman/8.0/en/time-zone-support.html) for details on how to use this feature.
+
 ## <a id="3-0-0"></a> v3.0.0
 
 **Release Date: April 5th, 2023**


### PR DESCRIPTION
We have recently completed a feature that allows users to specify a named time zone rather than a offset from UTC if they would prefer the database server perform time zone conversions.

The database server defaults to UTC and previously a user would have to specify an offset to do similar conversions, e.g. `time_zone = '-05:00'` and this would not follow daylight saving time shifts. 

Now a user may set an connector level option such as `time_zone = 'US/Eastern'` or use built-in MySQL Server functions like `SELECT SELECT CONVERT_TZ(NOW(), 'UTC', 'US/Eastern');` to do these conversions.

I left a rather terse release note that points to the MySQL documentation for this feature.   We can provide further detail if necessary.