### PR TITLE
document all release dependencies in compatibility table

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -52,14 +52,23 @@ The following components are compatible with this release:
   <tr><td>Percona Server</td><td>8.0.32-24*</td></tr>
   <tr><td>Percona Server</td><td>5.7.42-46</td></tr>
   <tr><td>Percona XtraDB Cluster</td><td>8.0.32-24*</td></tr>
-  <tr><td>Percona XtraDB Cluster</td><td>5.7.41-31.65</td></tr>
+  <tr><td>Percona XtraDB Cluster</td><td>5.7.41-31.65*</td></tr>
   <tr><td>Percona XtraBackup</td><td>8.0.32-26*</td></tr>
   <tr><td>Percona XtraBackup</td><td>2.4.28</td></tr>
-  <tr><td>pxc-release</td><td>1.0.14*</td></tr>
+  <tr><td>adbr-release</td><td>0.83.0*</td></tr>
+  <tr><td>bpm-release</td><td>1.2.4*</td></tr>
+  <tr><td>cf-cli-release</td><td>1.45.0*</td></tr>
+  <tr><td>cf-service-gateway-release</td><td>114.0.0*</td></tr>
+  <tr><td>count-cores-indicator-release</td><td>2.0.0*</td></tr>
+  <tr><td>dedicated-mysql-release</td><td>0.187.14*</td></tr>
+  <tr><td>dedicated-mysql-adapter-release</td><td>0.340.12*</td></tr>
+  <tr><td>loggregator-agent-release</td><td>6.5.12*</td></tr>
   <tr><td>mysql-backup-release</td><td>2.27.0*</td></tr>
   <tr><td>mysql-monitoring-release</td><td>10.1.0*</td></tr>
-  <tr><td>dedicated-mysql-release</td><td>0.187.14*</td></tr>
-
+  <tr><td>on-demand-service-broker-release</td><td>0.43.2*</td></tr>
+  <tr><td>pxc-release</td><td>1.0.14*</td></tr>
+  <tr><td>routing-release</td><td>0.275.0*</td></tr>
+  <tr><td>service-metrics-release</td><td>2.0.30*</td></tr>
 </table>
 
 ## <a id="3-0-0"></a> v3.0.0


### PR DESCRIPTION
Traditionally these release notes only documented the "mysql" releases, but there has been some requests to document our other dependencies to make it easier to know if a feature, bugfix or CVE was address in a version shipped with the latest tile.

This is an initial PR introducing this pattern, following the approach of the TAS and RabbitMQ tiles.

If you think it would be useful we can backport to earlier versions.

[#185666740](https://www.pivotaltracker.com/story/show/185666740)

Which other branches should this be merged with (if any)?  This is specific to the 3.0.1 release
