### PR TITLE
Update compatibility table for MySQL 2.10 tile

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -58,10 +58,20 @@ The following components are compatible with this release:
   <tr><td>Percona Server</td><td>5.7.42-46*</td></tr>
   <tr><td>Percona XtraDB Cluster</td><td>5.7.42-31.65</td></tr>
   <tr><td>Percona XtraBackup</td><td>2.4.28</td></tr>
-  <tr><td>mysql-backup-release</td><td>2.22.0*</td></tr>
-  <tr><td>mysql-monitoring-release</td><td>9.25.0*</td></tr>
+  <tr><td>adbr-release</td><td>0.83.0*</td></tr>
+  <tr><td>bpm-release</td><td>1.2.3*</td></tr>
+  <tr><td>cf-cli-release</td><td>1.45.0*</td></tr>
+  <tr><td>cf-service-gateway-release</td><td>114.0.0*</td></tr>
+  <tr><td>count-cores-indicator-release</td><td>2.0.0*</td></tr>
+  <tr><td>dedicated-mysql-adapter-release</td><td>0.298.25*</td></tr>
+  <tr><td>dedicated-mysql-release</td><td>0.164.15*</td></tr>
+  <tr><td>loggregator-agent-release</td><td>6.5.11*</td></tr>
+  <tr><td>mysql-backup-release</td><td>2.27.0*</td></tr>
+  <tr><td>mysql-monitoring-release</td><td>10.1.0*</td></tr>
+  <tr><td>on-demand-service-broker-release</td><td>0.43.2*</td></tr>
   <tr><td>pxc-release</td><td>0.54.0*</td></tr>
-
+  <tr><td>routing-release</td><td>0.275.0*</td></tr>
+  <tr><td>service-metrics-release</td><td>2.0.29*</td></tr>
 </table>
 
 ## <a id="2-10-10"></a> v2.10.10


### PR DESCRIPTION
We failed to update a couple dependencies in our previous PR it seems, so fixed here.

Which other branches should this be merged with (if any)? None, this is specific to 2.10.11
