### PR TITLE
use-multi-site: Update docs for cf-cli v8

### DIFF
--- a/customize-access.html.md.erb
+++ b/customize-access.html.md.erb
@@ -64,10 +64,7 @@ To create and find read-only credentials for an existing service instance:
      "username": "973eb219bd554dfc9794bc29a301bcb1"
     }</pre>
 
-    <p class="note caution">
-    <span class="note__title">Caution</span> Version 8 of the cf CLI has a different response than lesser versions of cf CLI.
-    Version 8 of the cf CLI has a top-level `credentials` key. Lesser versions of the cf CLI do not have a top-level `credentials` key.
-    </p>
+    >**Caution** In cf CLI v8, the response includes a top-level `credentials` key. Earlier versions of the cf CLI do not include a top-level `credentials` key.
 
 ## <a id="username"></a> Creating custom username credentials
 
@@ -117,7 +114,4 @@ To create and find custom username credentials for an existing service instance:
      "username": "myuser"
     }</pre>
 
-    <p class="note caution">
-    <span class="note__title">Caution</span> Version 8 of the cf CLI has a different response than lesser versions of cf CLI.
-    Version 8 of the cf CLI has a top-level `credentials` key. Lesser versions of the cf CLI do not have a top-level `credentials` key.
-    </p>
+    >**Caution** In cf CLI v8, the response includes a top-level `credentials` key. Earlier versions of the cf CLI do not include a top-level `credentials` key.

--- a/customize-access.html.md.erb
+++ b/customize-access.html.md.erb
@@ -64,6 +64,11 @@ To create and find read-only credentials for an existing service instance:
      "username": "973eb219bd554dfc9794bc29a301bcb1"
     }</pre>
 
+    <p class="note caution">
+    <span class="note__title">Caution</span> Version 8 of the cf-cli has a different response than lesser versions of cf-cli.
+    Version 8 of the cf-cli has a top-level `credentials` key. Lesser versions of the cf-cli do not have a top-level `credentials` key.
+    </p>
+
 ## <a id="username"></a> Creating custom username credentials
 
 <%= vars.product_short %> enables space developers to create custom usernames for service keys and service bindings. You can create these credentials for users that want to access the database with a specific username.
@@ -111,3 +116,8 @@ To create and find custom username credentials for an existing service instance:
      "uri": "mysql://myuser:bdjq5o19ax4suzmg@a7113e41-7254-4f5a-a0cf-a88b052c8b10.mysql.service.internal:3306/service_instance_db?reconnect=true",
      "username": "myuser"
     }</pre>
+
+    <p class="note caution">
+    <span class="note__title">Caution</span> Version 8 of the cf-cli has a different response than lesser versions of cf-cli.
+    Version 8 of the cf-cli has a top-level `credentials` key. Lesser versions of the cf-cli do not have a top-level `credentials` key.
+    </p>

--- a/customize-access.html.md.erb
+++ b/customize-access.html.md.erb
@@ -65,8 +65,8 @@ To create and find read-only credentials for an existing service instance:
     }</pre>
 
     <p class="note caution">
-    <span class="note__title">Caution</span> Version 8 of the cf-cli has a different response than lesser versions of cf-cli.
-    Version 8 of the cf-cli has a top-level `credentials` key. Lesser versions of the cf-cli do not have a top-level `credentials` key.
+    <span class="note__title">Caution</span> Version 8 of the cf CLI has a different response than lesser versions of cf CLI.
+    Version 8 of the cf CLI has a top-level `credentials` key. Lesser versions of the cf CLI do not have a top-level `credentials` key.
     </p>
 
 ## <a id="username"></a> Creating custom username credentials
@@ -118,6 +118,6 @@ To create and find custom username credentials for an existing service instance:
     }</pre>
 
     <p class="note caution">
-    <span class="note__title">Caution</span> Version 8 of the cf-cli has a different response than lesser versions of cf-cli.
-    Version 8 of the cf-cli has a top-level `credentials` key. Lesser versions of the cf-cli do not have a top-level `credentials` key.
+    <span class="note__title">Caution</span> Version 8 of the cf CLI has a different response than lesser versions of cf CLI.
+    Version 8 of the cf CLI has a top-level `credentials` key. Lesser versions of the cf CLI do not have a top-level `credentials` key.
     </p>

--- a/multi-site-trigger-failover.html.md.erb
+++ b/multi-site-trigger-failover.html.md.erb
@@ -410,9 +410,9 @@ To reconfigure replication for the service instances:
       }</pre>
 
     <p class="note caution">
-    <span class="note__title">Caution</span> Version 8 of the cf-cli has a different response than lesser versions of cf-cli.
-    Version 8 of the cf-cli has a top-level `credentials` key. Lesser versions of the cf-cli do not have a top-level `credentials` key.
-    These docs assume version 8 of the cf-cli.
+    <span class="note__title">Caution</span> Version 8 of the cf CLI has a different response than lesser versions of cf CLI.
+    Version 8 of the cf CLI has a top-level `credentials` key. Lesser versions of the cf CLI do not have a top-level `credentials` key.
+    These docs assume version 8 of the cf CLI.
     </p>
 
 1. Record the output of the previous command and remove the `credentials` key.
@@ -510,9 +510,9 @@ To reconfigure replication for the service instances:
       }</pre>
 
    <p class="note caution">
-   <span class="note__title">Caution</span> Version 8 of the cf-cli has a different response than lesser versions of cf-cli.
-   Version 8 of the cf-cli has a top-level `credentials` key. Lesser versions of the cf-cli do not have a top-level `credentials` key.
-   These docs assume less than version 8 of the cf-cli.
+   <span class="note__title">Caution</span> Version 8 of the cf CLI has a different response than lesser versions of cf CLI.
+   Version 8 of the cf CLI has a top-level `credentials` key. Lesser versions of the cf CLI do not have a top-level `credentials` key.
+   These docs assume less than version 8 of the cf CLI.
    </p>
 
 1. Record the output of the previous command and remove the `credentials` key.

--- a/multi-site-trigger-failover.html.md.erb
+++ b/multi-site-trigger-failover.html.md.erb
@@ -409,11 +409,7 @@ To reconfigure replication for the service instances:
         }
       }</pre>
 
-    <p class="note caution">
-    <span class="note__title">Caution</span> Version 8 of the cf CLI has a different response than lesser versions of cf CLI.
-    Version 8 of the cf CLI has a top-level `credentials` key. Lesser versions of the cf CLI do not have a top-level `credentials` key.
-    These docs assume version 8 of the cf CLI.
-    </p>
+    >**Caution** In cf CLI v8, the response includes a top-level `credentials` key. Earlier versions of the cf CLI do not include a top-level `credentials` key. This procedure assumes that you are using cf CLI v8.
 
 1. Record the output of the previous command and remove the `credentials` key.
 
@@ -509,11 +505,7 @@ To reconfigure replication for the service instances:
         }
       }</pre>
 
-   <p class="note caution">
-   <span class="note__title">Caution</span> Version 8 of the cf CLI has a different response than lesser versions of cf CLI.
-   Version 8 of the cf CLI has a top-level `credentials` key. Lesser versions of the cf CLI do not have a top-level `credentials` key.
-   These docs assume less than version 8 of the cf CLI.
-   </p>
+   >**Caution** In cf CLI v8, the response includes a top-level `credentials` key. Earlier versions of the cf CLI do not include a top-level `credentials` key. This procedure assumes that you are using cf CLI v8.
 
 1. Record the output of the previous command and remove the `credentials` key.
 

--- a/multi-site-trigger-failover.html.md.erb
+++ b/multi-site-trigger-failover.html.md.erb
@@ -409,6 +409,12 @@ To reconfigure replication for the service instances:
         }
       }</pre>
 
+    <p class="note caution">
+    <span class="note__title">Caution</span> Version 8 of the cf-cli has a different response than lesser versions of cf-cli.
+    Version 8 of the cf-cli has a top-level `credentials` key. Lesser versions of the cf-cli do not have a top-level `credentials` key.
+    These docs assume version 8 of the cf-cli.
+    </p>
+
 1. Record the output of the previous command and remove the `credentials` key.
 
 1. Log in to the deployment for your secondary foundation by running:
@@ -502,6 +508,12 @@ To reconfigure replication for the service instances:
             }
         }
       }</pre>
+
+   <p class="note caution">
+   <span class="note__title">Caution</span> Version 8 of the cf-cli has a different response than lesser versions of cf-cli.
+   Version 8 of the cf-cli has a top-level `credentials` key. Lesser versions of the cf-cli do not have a top-level `credentials` key.
+   These docs assume less than version 8 of the cf-cli.
+   </p>
 
 1. Record the output of the previous command and remove the `credentials` key.
 

--- a/multi-site-trigger-failover.html.md.erb
+++ b/multi-site-trigger-failover.html.md.erb
@@ -396,18 +396,20 @@ To reconfigure replication for the service instances:
     Getting key host-info-key for service instance primary-node as admin...
 
       {
-        "replication": {
-            "peer-info": {
-              "hostname": "primary.bosh",
-              "ip": "10.0.19.12",
-              "system_domain": "sys.primary-domain.com",
-              "uuid": "ab12cd34-5678-91e2-345f-67891h234567"
-          },
-          "role": "leader"
+        "credentials": {
+            "replication": {
+                "peer-info": {
+                  "hostname": "primary.bosh",
+                  "ip": "10.0.19.12",
+                  "system_domain": "sys.primary-domain.com",
+                  "uuid": "ab12cd34-5678-91e2-345f-67891h234567"
+              },
+              "role": "leader"
+            }
         }
       }</pre>
 
-1. Record the output of the previous command.
+1. Record the output of the previous command and remove the `credentials` key.
 
 1. Log in to the deployment for your secondary foundation by running:
 
@@ -484,22 +486,24 @@ To reconfigure replication for the service instances:
     Getting key cred-key for service instance secondary as admin...
 
       {
-        "replication": {
-          "credentials": {
-            "password": "a22aaa2a2a2aaaaa",
-            "username": "6bf07ae455a14064a9073cec8696366c"
-          },
-          "peer-info": {
-            "hostname": "secondary.bosh",
-            "ip": "10.0.17.12",
-            "system_domain": "sys.secondary-domain.com",
-            "uuid": "zy98xw76-5432-19v8-765u-43219t876543"
-          },
-          "role": "follower"
+        "credentials": {
+            "replication": {
+              "credentials": {
+                "password": "a22aaa2a2a2aaaaa",
+                "username": "6bf07ae455a14064a9073cec8696366c"
+              },
+              "peer-info": {
+                "hostname": "secondary.bosh",
+                "ip": "10.0.17.12",
+                "system_domain": "sys.secondary-domain.com",
+                "uuid": "zy98xw76-5432-19v8-765u-43219t876543"
+              },
+              "role": "follower"
+            }
         }
       }</pre>
 
-1. Record the output of the previous command.
+1. Record the output of the previous command and remove the `credentials` key.
 
 1. Log in to the deployment for your primary foundation by running:
 

--- a/tools.html.md.erb
+++ b/tools.html.md.erb
@@ -86,6 +86,11 @@ command:
       }
     </pre>
 
+   <p class="note caution">
+    <span class="note__title">Caution</span> Version 8 of the cf-cli has a different response than lesser versions of cf-cli.
+    Version 8 of the cf-cli has a top-level `credentials` key. Lesser versions of the cf-cli do not have a top-level `credentials` key.
+   </p>
+
 1. Record the values for the following:
     * `hostname`
     * `name`

--- a/tools.html.md.erb
+++ b/tools.html.md.erb
@@ -86,10 +86,7 @@ command:
       }
     </pre>
 
-   <p class="note caution">
-    <span class="note__title">Caution</span> Version 8 of the cf CLI has a different response than lesser versions of cf CLI.
-    Version 8 of the cf CLI has a top-level `credentials` key. Lesser versions of the cf CLI do not have a top-level `credentials` key.
-   </p>
+   >**Caution** In cf CLI v8, the response includes a top-level `credentials` key. Earlier versions of the cf CLI do not include a top-level `credentials` key.
 
 1. Record the values for the following:
     * `hostname`

--- a/tools.html.md.erb
+++ b/tools.html.md.erb
@@ -87,8 +87,8 @@ command:
     </pre>
 
    <p class="note caution">
-    <span class="note__title">Caution</span> Version 8 of the cf-cli has a different response than lesser versions of cf-cli.
-    Version 8 of the cf-cli has a top-level `credentials` key. Lesser versions of the cf-cli do not have a top-level `credentials` key.
+    <span class="note__title">Caution</span> Version 8 of the cf CLI has a different response than lesser versions of cf CLI.
+    Version 8 of the cf CLI has a top-level `credentials` key. Lesser versions of the cf CLI do not have a top-level `credentials` key.
    </p>
 
 1. Record the values for the following:

--- a/use-multi-site.html.md.erb
+++ b/use-multi-site.html.md.erb
@@ -211,13 +211,9 @@ To configure replication for your <%= vars.single_leader_plan %> leader-follower
         }
       }</pre>
    
-    <p class="note caution">
-    <span class="note__title">Caution</span> Version 8 of the cf CLI has a different response than lesser versions of cf CLI.
-    Version 8 of the cf CLI has a top-level `credentials` key. Lesser versions of the cf CLI do not have a top-level `credentials` key.
-    These docs assume version 8 of the cf CLI.
-    </p>
+    >**Caution** In cf CLI v8, the response includes a top-level `credentials` key. Earlier versions of the cf CLI do not include a top-level `credentials` key. This procedure assumes that you are using cf CLI v8.
    
-1. Record the output of the previous command and remove the `credentials` key.
+1. Record the output of the previous command, and remove the `credentials` key.
 1. Log in to the deployment for your primary foundation by running:
 
     ```
@@ -321,13 +317,9 @@ To configure replication for your <%= vars.single_leader_plan %> leader-follower
         }
       }</pre>
 
-   <p class="note caution">
-   <span class="note__title">Caution</span> Version 8 of the cf CLI has a different response than lesser versions of cf CLI.
-   Version 8 of the cf CLI has a top-level `credentials` key. Lesser versions of the cf CLI do not have a top-level `credentials` key.
-   These docs assume less than version 8 of the cf CLI.
-   </p>
+   >**Caution** In cf CLI v8, the response includes a top-level `credentials` key. Earlier versions of the cf CLI do not include a top-level `credentials` key. This procedure assumes that you are using cf CLI v8.
 
-1. Record the output of the previous command and remove the `credentials` key.
+1. Record the output of the previous command, and remove the `credentials` key.
 1. Log in to the deployment for your secondary foundation by running:
 
     ```console

--- a/use-multi-site.html.md.erb
+++ b/use-multi-site.html.md.erb
@@ -198,17 +198,19 @@ To configure replication for your <%= vars.single_leader_plan %> leader-follower
     Getting key host-info-key for service instance secondary-node as admin...
 
       {
-        "replication": {
-            "peer-info": {
-              "hostname": "secondary.bosh",
-              "ip": "10.0.19.12",
-              "system_domain": "sys.secondary-domain.com",
-              "uuid": "ab12cd34-5678-91e2-345f-67891h234567"
-          },
-          "role": "leader"
+        "credentials": {
+            "replication": {
+                "peer-info": {
+                  "hostname": "secondary.bosh",
+                  "ip": "10.0.19.12",
+                  "system_domain": "sys.secondary-domain.com",
+                  "uuid": "ab12cd34-5678-91e2-345f-67891h234567"
+              },
+              "role": "leader"
+            }
         }
       }</pre>
-1. Record the output of the previous command.
+1. Record the output of the previous command and remove the `credentials` key.
 1. Log in to the deployment for your primary foundation by running:
 
     ```
@@ -295,22 +297,24 @@ To configure replication for your <%= vars.single_leader_plan %> leader-follower
     Getting key cred-key for service instance primary as admin...
 
       {
-        "replication": {
-          "credentials": {
-            "password": "a22aaa2a2a2aaaaa",
-            "username": "6bf07ae455a14064a9073cec8696366c"
-          },
-          "peer-info": {
-            "hostname": "primary.bosh",
-            "ip": "10.0.17.12",
-            "system_domain": "sys.primary-domain.com",
-            "uuid": "zy98xw76-5432-19v8-765u-43219t876543"
-          },
-          "role": "follower"
+        "credentials": {
+            "replication": {
+              "credentials": {
+                "password": "a22aaa2a2a2aaaaa",
+                "username": "6bf07ae455a14064a9073cec8696366c"
+              },
+              "peer-info": {
+                "hostname": "primary.bosh",
+                "ip": "10.0.17.12",
+                "system_domain": "sys.primary-domain.com",
+                "uuid": "zy98xw76-5432-19v8-765u-43219t876543"
+              },
+              "role": "follower"
+            }
         }
       }</pre>
 
-1. Record the output of the previous command.
+1. Record the output of the previous command and remove the `credentials` key.
 1. Log in to the deployment for your secondary foundation by running:
 
     ```console

--- a/use-multi-site.html.md.erb
+++ b/use-multi-site.html.md.erb
@@ -212,9 +212,9 @@ To configure replication for your <%= vars.single_leader_plan %> leader-follower
       }</pre>
    
     <p class="note caution">
-    <span class="note__title">Caution</span> Version 8 of the cf-cli has a different response than lesser versions of cf-cli.
-    Version 8 of the cf-cli has a top-level `credentials` key. Lesser versions of the cf-cli do not have a top-level `credentials` key.
-    These docs assume version 8 of the cf-cli.
+    <span class="note__title">Caution</span> Version 8 of the cf CLI has a different response than lesser versions of cf CLI.
+    Version 8 of the cf CLI has a top-level `credentials` key. Lesser versions of the cf CLI do not have a top-level `credentials` key.
+    These docs assume version 8 of the cf CLI.
     </p>
    
 1. Record the output of the previous command and remove the `credentials` key.
@@ -322,9 +322,9 @@ To configure replication for your <%= vars.single_leader_plan %> leader-follower
       }</pre>
 
    <p class="note caution">
-   <span class="note__title">Caution</span> Version 8 of the cf-cli has a different response than lesser versions of cf-cli.
-   Version 8 of the cf-cli has a top-level `credentials` key. Lesser versions of the cf-cli do not have a top-level `credentials` key.
-   These docs assume less than version 8 of the cf-cli.
+   <span class="note__title">Caution</span> Version 8 of the cf CLI has a different response than lesser versions of cf CLI.
+   Version 8 of the cf CLI has a top-level `credentials` key. Lesser versions of the cf CLI do not have a top-level `credentials` key.
+   These docs assume less than version 8 of the cf CLI.
    </p>
 
 1. Record the output of the previous command and remove the `credentials` key.

--- a/use-multi-site.html.md.erb
+++ b/use-multi-site.html.md.erb
@@ -210,6 +210,13 @@ To configure replication for your <%= vars.single_leader_plan %> leader-follower
             }
         }
       }</pre>
+   
+    <p class="note caution">
+    <span class="note__title">Caution</span> Version 8 of the cf-cli has a different response than lesser versions of cf-cli.
+    Version 8 of the cf-cli has a top-level `credentials` key. Lesser versions of the cf-cli do not have a top-level `credentials` key.
+    These docs assume version 8 of the cf-cli.
+    </p>
+   
 1. Record the output of the previous command and remove the `credentials` key.
 1. Log in to the deployment for your primary foundation by running:
 
@@ -313,6 +320,12 @@ To configure replication for your <%= vars.single_leader_plan %> leader-follower
             }
         }
       }</pre>
+
+   <p class="note caution">
+   <span class="note__title">Caution</span> Version 8 of the cf-cli has a different response than lesser versions of cf-cli.
+   Version 8 of the cf-cli has a top-level `credentials` key. Lesser versions of the cf-cli do not have a top-level `credentials` key.
+   These docs assume less than version 8 of the cf-cli.
+   </p>
 
 1. Record the output of the previous command and remove the `credentials` key.
 1. Log in to the deployment for your secondary foundation by running:


### PR DESCRIPTION
- v3 api of cf adds top-level "credentials" key
- our adapter does not expect this, so we tell our users to manually remove the "credentials" key

[#184764232](https://www.pivotaltracker.com/story/show/184764232)

Which other branches should this be merged with (if any)?
- 3.1
- 3.0
- 2.10
- 2.9
