### PR TITLE
Adds release note based on changes made to routing release

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -19,6 +19,16 @@ MySQL patch and VMware releasing <%= vars.product_full %> containing that patch.
 
 + In the **Security** pane of the MySQL tile **Settings** page, setting **TLS Options** to **Optional** allows, but does not enforce, TLS connections between apps and <%= vars.product_full %> service instances.
 
+## <a id="2-10-15"></a> v2.10.15
+
+**Release Date: TBD**
+
+### Breaking Changes
+- Brokers connect to Nats using TLS
+- Service Gateway connects to Routing using TLS
+
+These changes mean that VMware SQL with MySQL for Tanzu Application Service supports TAS versions starting at 2.11
+
 ## <a id="2-10-14"></a> v2.10.14
 
 **Release Date: Oct 24th, 2023**


### PR DESCRIPTION
The non-TLS option is no longer supported, so changes were made to the tile and adapter that means our 2.10 tile will no longer work with older versions of TAS

We don't have a planned patch release yet, but we need to call out this breaking change

[#186591474](https://www.pivotaltracker.com/story/show/186591474)

Which other branches should this be merged with (if any)?
NA

For added reference, the RabbitMQ team did a similar PR for their docs - https://github.com/pivotal-cf/docs-rabbitmq-pcf/pull/687/files
