### PR TITLE
Adds warning for new multisite feature

### DIFF
--- a/about-multi-site.html.md.erb
+++ b/about-multi-site.html.md.erb
@@ -280,6 +280,23 @@ data centers are a geographically farther apart experience higher latencies.
 For information about the standard networking rules,
 see [Required Networking Rules for <%= vars.single_leader_plan %>](./about.html#multi-site-ports).
 
+### <a id="avail-zones"></a> Availability zones
+
+With the addition of a new feature that allows scaling up and down between
+single node multisite leaders and Highly Available (HA) leaders, extra care
+must be taken to ensure that the availability zones (AZ) are compatible between
+the two plans.
+
+To minimize impact of an availability zone (AZ) outage and to remove single points
+of failure, VMware recommends that you provision three AZs if using HA deployments.
+With three AZs, nodes are deployed to separate AZs.
+
+<p class="note important">
+<span class="note__title"> Important</span> In order to scale between the two plan types, the availability zones configured for
+the HA plan must match those configured for the single node multisite plan.</p>
+
+For more information, see [Availability Using Multiple AZs](./recommended.html#azs)
+in _<%= vars.product_full %> Recommended Usage and Limitations_.
 
 ## <a id='limitations'></a> <%= vars.single_leader_plan %> limitations
 


### PR DESCRIPTION
To be able to safely switch between a 3 node HA plan and a 1 node multisite plan, the AZ's for the three node plan and the 1 node plan must match

We ran into a bug in CI when this wasn't the case: HA - az1, az2, az3
Single node - az2

In this setup, it's possible for the HA plan to scale down to one node, but that final node may be in az1 or az3, which is not supported by the single node plan

We get a CF error when this is the case, but it's not obvious why the update fails, so we want to try and highlight this in the docs

[#186826765](https://www.pivotaltracker.com/story/show/186826765)

Authored-by: Ryan Wittrup <rwittrup@vmware.com>

Which other branches should this be merged with (if any)?
