### PR TITLE
Remove "No metrics from log cache" troubleshooting note

### DIFF
--- a/troubleshoot-instances.html.md.erb
+++ b/troubleshoot-instances.html.md.erb
@@ -15,57 +15,8 @@ owner: MySQL
 <p>Errors common to on-demand services are:</p>
 
 <ul>
-<li><p><a href="#no-metrics">No metrics from log cache</a></p></li>
 <li><p><a href="#no-service-gateway-ports">When Using Service-Gateway Access, create-service or update-service Fails</a></p></li>
 </ul>
-
-<style>
-
-
-main table {
-  table-layout: fixed;
-}
-
-</style>
-
-<p><a name="no-metrics"></a></p>
-
-<div>
-
-  <table class="nice">
-    <style>
-      main table {
-        table-layout: fixed;
-      }
-    </style>
-  <col width="20%">
-  <col width="80%">
-  <tr>
-  <th colspan="2" style="text-align: left;"> <br>
-    No Metrics from Log Cache
-  <br><br></th>
-  </tr>
-
-  <tr>
-    <th>Symptom</th>
-    <td>You receive no metrics when running the <code>cf tail</code> command.</td>
-  </tr>
-
-  <tr>
-    <th>Cause</th>
-    <td>This might happen because the Firehose is deactivated in the TAS for VMs tile.</td>
-  </tr>
-
-  <tr>
-    <th style="vertical-align: top; padding-top: 1em;">Solution</th>
-    <td>Ask your operator to ensure that the <strong>V2 Firehose</strong> check box is activated,
-  and the <strong>Enable Log Cache syslog ingestion</strong> check box is deactivated in the TAS for VMs tile.
-  For more information about configuring these check boxes, see
-  <a href="https://docs.pivotal.io/application-service/operating/logging-config-opsman.html#syslog-forward">Enable Syslog Forwarding</a>.</td>
-  </tr>
-
-</table>
-</div>
 
 <style>
 


### PR DESCRIPTION
Metrics from service instances are expected to be visible in Log Cache when the service instances co-locate the syslog agent and Log Cache is using syslog ingestion.