### PR TITLE
update tile v3.2 docs for mysql 5.7 removal

### DIFF
--- a/backup-mysqldump.html.md.erb
+++ b/backup-mysqldump.html.md.erb
@@ -131,7 +131,7 @@ To back up your <%= vars.product_short %> data manually:
     </pre>
 
     For more information about the mysqldump utility, see
-    [mysqldump](https://dev.mysql.com/doc/refman/5.7/en/using-mysqldump.html) in the MySQL Documentation.
+    [mysqldump](https://dev.mysql.com/doc/refman/8.0/en/using-mysqldump.html) in the MySQL Documentation.
 
 
 ### <a id="restore-backup"></a> Restore from a <%= vars.product_short %> logical backup

--- a/backup-restore.html.md.erb
+++ b/backup-restore.html.md.erb
@@ -97,25 +97,24 @@ it uploads two files with Unix epoch-timestamped filenames:
 The metadata file contains information about the backup that looks similar to the following:
 
 ```
-ibbackup_version = 2.4.5
-end_time = 2017-04-24 21:00:03
+end_time = 2024-01-29 18:56:21
 lock_time = 0
-binlog_pos =
-incremental = N
-encrypted = N
-server_version = 5.7.16-10-log
-start_time = 2017-04-24 21:00:00
-tool_command = --user=admin --password=... --stream=tar tmp/
-innodb_from_lsn = 0
-innodb_to_lsn = 2491844
-format = tar
-compact = N
-name =
-tool_name = innobackupex
+innodb_to_lsn = 23136604
 partial = N
+tool_name = xtrabackup
+start_time = 2024-01-29 18:56:18
 compressed = N
-uuid = fd13cf26-2930-11e7-871e-42010a000807
-tool_version = 2.4.5
+encrypted = N
+incremental = N
+format = xbstream
+name =
+tool_command = --defaults-file=/var/vcap/jobs/streaming-mysql-backup-tool/config/mysql-defaults-file.cnf --backup --stream=xbstream --target-dir=/var/vcap/store/xtrabackup_tmp
+tool_version = 8.0.35-30
+binlog_pos = filename 'mysql-bin.000012', position '197', GTID of the last change 'cfe096a6-bebf-11ee-be4e-4fcff573e33e:1-345'
+uuid = 180170b2-bed8-11ee-9e4f-42010a000122
+ibbackup_version = 8.0.35-30
+server_version = 8.0.35-27
+innodb_from_lsn = 0
 ```
 
 The most important entries in the metadata file are the following:

--- a/change-default.html.md.erb
+++ b/change-default.html.md.erb
@@ -167,7 +167,7 @@ For example, if your database had the table names `TableName` and `TABLEname`, w
 lowercase table names both of the names change to `tablename` and are interpreted as the same table.
 
 For more information, see the
-[MySQL documentation](https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_lower_case_table_names).
+[MySQL documentation](https://dev.mysql.com/doc/refman/8.0/en/identifier-case-sensitivity.html).
 
 The following table describes how to use the `enable_lower_case_table_names` optional parameter:
 
@@ -231,9 +231,9 @@ optional parameters to change the character sets used in databases:
 
   <tr>
     <th><strong>Description</strong></th>
-    <td>You can set this to any MySQL 5.7 supported character set.
+    <td>You can set this to any MySQL supported character set.
       For information about character sets and collations,
-      see the  <a href="https://dev.mysql.com/doc/refman/5.7/en/charset-mysql.html">MySQL documentation</a>.</td>
+      see the  <a href="https://dev.mysql.com/doc/refman/8.0/en/charset-mysql.html">MySQL documentation</a>.</td>
   </tr>
 
   <tr>
@@ -265,7 +265,7 @@ optional parameters to change the character sets used in databases:
 
       For instructions for
       viewing available and default collations,
-      see the <a href="https://dev.mysql.com/doc/refman/5.7/en/charset-charsets.html">
+      see the <a href="https://dev.mysql.com/doc/refman/8.0/en/charset-mysql.html">
       MySQL documentation</a>.</td>
   </tr>
 
@@ -323,7 +323,7 @@ for single node, HA cluster, or multi-site replication plans.</p>
 <p> In <%= vars.product_short %>, replication is called sync, rather than semi-sync.
   This is because it is as synchronous as possible given the limits of MySQL. For more information about MySQL semi-sync
   replication,
-  see the <a href="https://dev.mysql.com/doc/refman/5.7/en/replication-semisync.html">MySQL documentation</a>.
+  see the <a href="https://dev.mysql.com/doc/refman/8.0/en/replication-semisync.html">MySQL documentation</a>.
 </p>
 
 ### <a id='replication-timeout'></a>Synchronous replication timeout
@@ -439,7 +439,7 @@ The following table describes how to use the `optimize_for_short_words` optional
     how much data is changed in the full-text index.
     <br>
     For more information about the <code>innodb_ft_min_token_size</code> system variable,
-    see the <a href="https://dev.mysql.com/doc/refman/5.7/en/innodb-fulltext-index.html">MySQL
+    see the <a href="https://dev.mysql.com/doc/refman/8.0/en/innodb-fulltext-index.html">MySQL
     documentation</a>.
     <br><br>
     To remove full-text index entries for deleted records or old records:<br><br>
@@ -458,7 +458,7 @@ The following table describes how to use the `optimize_for_short_words` optional
     </ol>
 
     For more information about InnoDB full-text index deletion,
-    see the <a href="https://dev.mysql.com/doc/refman/5.7/en/innodb-fulltext-index.html#innodb-fulltext-index-deletion">MySQL
+    see the <a href="https://dev.mysql.com/doc/refman/8.0/en/innodb-fulltext-index.html#innodb-fulltext-index-deletion">MySQL
     documentation</a>.
     </td>
   </tr>
@@ -491,10 +491,10 @@ The following table describes how to use the `wsrep_applier_threads` optional pa
   <tr>
     <th><strong>Description</strong></th>
     <td>
-      Specifies the number of threads that can apply replication transactions in parallel in a high-availability cluster. VMware MySQL for VMs defaults to 4 threads, whereas Percona XtraDB Cluster 5.7 defaults to 1.
+      Specifies the number of threads that can apply replication transactions in parallel in a high-availability cluster. VMware MySQL for VMs defaults the number of threads to match the number of vCPUs on the MySQL VM, whereas Percona XtraDB Cluster defaults to 1.
 
       For further details, see the
-      <a href="https://docs.percona.com/percona-xtradb-cluster/5.7/wsrep-system-index.html#wsrep_slave_threads">Percona XtraDB Cluster Docs</a>.
+      <a href="https://docs.percona.com/percona-xtradb-cluster/8.0/wsrep-system-index.html#wsrep_applier_threads">Percona XtraDB Cluster Docs</a>.
 
       <p class="note important">
 <span class="note__title"> Important</span> This parameter only applies to "high-availablity" service plans, and is rejected for service

--- a/install-config.html.md.erb
+++ b/install-config.html.md.erb
@@ -305,12 +305,8 @@ you must configure a <%= vars.single_leader_plan %> plan in both foundations usi
   <table>
     <tr><th>Field</th><th>Description</th></tr>
     <tr><td><strong>MySQL Default Version</strong></td>
-        <td>Select one of the following options:<br>
-            <ul><li> <strong>MySQL 5.7</strong>: (Default selection) Sets MySQL 5.7 as the default version for the service plan.
-                </li>
-                <li><strong>MySQL 8.0</strong>: Sets MySQL 8.0 as the default version for the service plan.
-                </li>
-        </ul></td></tr>
+        <td><strong>MySQL 8.0</strong> will be selected as the default and only option.
+    </tr>
     <tr><td><strong>Service Plan Access</strong></td>
         <td>Select one of the following options:<br>
             <ul><li> <strong>Enable (Default):</strong> Gives access to all orgs
@@ -458,7 +454,7 @@ a detailed description of the configurable fields."](./images/mysql-config.png)
             This sets the MySQL server system variable
             <code>lower_case_table_names</code> to <code>1</code> on all <%= vars.product_short %> instances by default. <br>
             To permit developers to override this default, see the following check box. <br>
-            For more information about <code>lower_case_table_names</code> , see the <a href="https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_lower_case_table_names">MySQL documentation</a>.
+            For more information about <code>lower_case_table_names</code> , see the <a href="https://dev.mysql.com/doc/refman/8.0/en/identifier-case-sensitivity.html">MySQL documentation</a>.
             <p class="note warning"><strong>Warning:</strong> Before you activate this feature, ensure all tables have lowercase names. Tables with uppercase names are inaccessible after enabling lowercase table names.</p>
          </td></tr>
     <tr><td><strong>Allow Developers To Override Lower Case Table Names</strong></td>
@@ -468,7 +464,7 @@ a detailed description of the configurable fields."](./images/mysql-config.png)
         <td>Select this check box to activate data downloading from the local file system of the client.
             VMware discourages selecting this check box. Before you activate local in-file,
             review the security issues associated with <code>LOAD DATA LOCAL</code>.
-            See the <a href="https://dev.mysql.com/doc/refman/5.7/en/load-data-local-security.html">MySQL documentation</a>.
+            See the <a href="https://dev.mysql.com/doc/refman/8.0/en/load-data-local-security.html">MySQL documentation</a>.
     </td></tr>
     <tr>
       <a name="limit-disk-use"></a>
@@ -480,7 +476,7 @@ a detailed description of the configurable fields."](./images/mysql-config.png)
     </td></tr>
     <tr><td><strong>Wait Timeout</strong></td>
         <td>Enter the amount of time in seconds that MySQL waits to close inactive connections.
-            For more information about <code>wait\_timeout</code>, see the <a href="https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_wait_timeout">MySQL documentation</a>.
+            For more information about <code>wait\_timeout</code>, see the <a href="https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_wait_timeout">MySQL documentation</a>.
     </td></tr>
   </table>
 
@@ -649,11 +645,11 @@ To activate monitoring and logging in the MySQL service:
     <tr><td><strong>Enable User Statistics Logging</strong></td>
         <td>Select this check box to collect user statistics. You can use these statistics to better
           understand server activity and identify load sources.
-            For more information about user statistics, see the <a href="https://www.percona.com/doc/percona-server/5.7/diagnostics/user_stats.html">MySQl documentation</a>.
+            For more information about user statistics, see the <a href="https://docs.percona.com/percona-server/8.0/user-stats.html">MySQL documentation</a>.
             </td></tr>
     <tr><td><strong>Enable Server Activity Logging</strong></td>
         <td>Select this check box to record that connects to the servers and what queries are processed using the Percona Audit Log Plugin.
-            For more information, see the <a href="https://www.percona.com/doc/percona-server/5.7/management/audit_log_plugin.html">Percona documentation</a>
+            For more information, see the <a href="https://docs.percona.com/percona-server/8.0/audit-log-plugin.html">Percona documentation</a>
             <p class="note"><strong>Note:</strong> MySQL audit logs are not forwarded to the syslog server because they can contain personally identifying information (PII) and secrets.<br>
             You can use the <a href="https://community.pivotal.io/s/article/script-to-download-mysql-logs-for-pas-tile-ha-clusters"<code>download-logs</code></a> script to retrieve the logs, which each MySQL cluster node VM stores in <code>/var/vcap/store/mysql_audit_logs/</code>.
           </p>

--- a/install-config.html.md.erb
+++ b/install-config.html.md.erb
@@ -305,7 +305,7 @@ you must configure a <%= vars.single_leader_plan %> plan in both foundations usi
   <table>
     <tr><th>Field</th><th>Description</th></tr>
     <tr><td><strong>MySQL Default Version</strong></td>
-        <td><strong>MySQL 8.0</strong> will be selected as the default and only option.
+        <td><strong>MySQL 8.0</strong> is selected as the default and only option.
     </tr>
     <tr><td><strong>Service Plan Access</strong></td>
         <td>Select one of the following options:<br>
@@ -454,7 +454,7 @@ a detailed description of the configurable fields."](./images/mysql-config.png)
             This sets the MySQL server system variable
             <code>lower_case_table_names</code> to <code>1</code> on all <%= vars.product_short %> instances by default. <br>
             To permit developers to override this default, see the following check box. <br>
-            For more information about <code>lower_case_table_names</code> , see the <a href="https://dev.mysql.com/doc/refman/8.0/en/identifier-case-sensitivity.html">MySQL documentation</a>.
+            For more information about <code>lower_case_table_names</code>, see the <a href="https://dev.mysql.com/doc/refman/8.0/en/identifier-case-sensitivity.html">MySQL documentation</a>.
             <p class="note warning"><strong>Warning:</strong> Before you activate this feature, ensure all tables have lowercase names. Tables with uppercase names are inaccessible after enabling lowercase table names.</p>
          </td></tr>
     <tr><td><strong>Allow Developers To Override Lower Case Table Names</strong></td>
@@ -645,7 +645,7 @@ To activate monitoring and logging in the MySQL service:
     <tr><td><strong>Enable User Statistics Logging</strong></td>
         <td>Select this check box to collect user statistics. You can use these statistics to better
           understand server activity and identify load sources.
-            For more information about user statistics, see the <a href="https://docs.percona.com/percona-server/8.0/user-stats.html">MySQL documentation</a>.
+            For more information about user statistics, see the <a href="https://docs.percona.com/percona-server/8.0/user-stats.html">Percona documentation</a>.
             </td></tr>
     <tr><td><strong>Enable Server Activity Logging</strong></td>
         <td>Select this check box to record that connects to the servers and what queries are processed using the Percona Audit Log Plugin.

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -19,8 +19,7 @@ MySQL patch and VMware releasing <%= vars.product_full %> containing that patch.
 
 >**Important**
 > 3.1.x is the last version of <%= vars.product_full %> that supports MySQL 5.7.
-> 3.2.0 and later only supports MySQL 8.0. If upgrading from an earlier <%= vars.product_short %> release, any plans previously configured with "MySQL Default Version" of 5.7 must be reconfigured to specify 8.0. See [Upgrading VMware SQL with MySQL for Tanzu Application Service](./upgrade.html) for details on upgrading the tile.
-
+> <%= vars.product_short %> 3.2.0 and later only support MySQL 8.0. If you are upgrading from an earlier release of <%= vars.product_short %>, you must reconfigure any plans previously configured with "MySQL Default Version" of 5.7 to specify 8.0. For more information about upgrading <%= vars.product_short %>, see [Upgrading VMware SQL with MySQL for Tanzu Application Service](./upgrade.html).
 
 This release includes the following changes:
 + Demoted multi-site leaders can be made writable again
@@ -28,12 +27,11 @@ This release includes the following changes:
 
 ### Breaking Changes
 
-+ **As of <%= vars.product_short %> v3.2.0, MySQL v5.7 is no longer supported.**:
++ **MySQL v5.7 is no longer supported.**:
 
-  Existing service plans that previously configured "MySQL Default Version" with "5.7" must be updated.   Service instances created with these plans will be updated to MySQL 8.0 when the instance is upgraded.  See [Upgrading VMware SQL with MySQL for Tanzu Application Service](./upgrade.html) for details on upgrading the tile.
+  Existing service plans that used a "MySQL Default Version" of "5.7" must be updated. Any service instance created with one of these plans will be updated to MySQL 8.0 when the instance is upgraded. For more information about upgrading <%= vars.product_short %>, see [Upgrading VMware SQL with MySQL for Tanzu Application Service](./upgrade.html).
 
 ### Resolved Issues
-
 
 ### Compatibility
 

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -17,10 +17,20 @@ MySQL patch and VMware releasing <%= vars.product_full %> containing that patch.
 
 **Release Date: TBD**
 
+>**Important**
+> 3.1.x is the last version of <%= vars.product_full %> that supports MySQL 5.7.
+> 3.2.0 and later only supports MySQL 8.0. If upgrading from an earlier <%= vars.product_short %> release, any plans previously configured with "MySQL Default Version" of 5.7 must be reconfigured to specify 8.0. See [Upgrading VMware SQL with MySQL for Tanzu Application Service](./upgrade.html) for details on upgrading the tile.
+
 
 This release includes the following changes:
 + Demoted multi-site leaders can be made writable again
 + A number of high and critical CVEs were addressed by updating the components to the latest version
+
+### Breaking Changes
+
++ **As of <%= vars.product_short %> v3.2.0, MySQL v5.7 is no longer supported.**:
+
+  Existing service plans that previously configured "MySQL Default Version" with "5.7" must be updated.   Service instances created with these plans will be updated to MySQL 8.0 when the instance is upgraded.  See [Upgrading VMware SQL with MySQL for Tanzu Application Service](./upgrade.html) for details on upgrading the tile.
 
 ### Resolved Issues
 

--- a/server-defaults.html.md.erb
+++ b/server-defaults.html.md.erb
@@ -83,7 +83,7 @@ to all service plans:
         <td>3</td>
         <td>This setting is the number of days before binary log files are automatically removed. <br>
         For more information, see
-        the <a href="https://dev.mysql.com/doc/refman/5.7/en/replication-options-binary-log.html#sysvar_expire_logs_days">MySQL documentation</a>.</td>
+        the <a href="https://dev.mysql.com/doc/refman/8.0/en/replication-options-binary-log.html#sysvar_binlog_expire_logs_seconds">MySQL documentation</a>.</td>
     </tr>
     <tr>
         <td><strong>InnoDB Transaction Log Durability</strong></td>
@@ -91,7 +91,7 @@ to all service plans:
         <td>1</td>
         <td>At each transaction commit, logs are written and flushed to disk.
             <br>For more information, see the
-            <a href="https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_flush_log_at_trx_commit">
+            <a href="https://dev.mysql.com/doc/refman/8.0/en/innodb-parameters.html#sysvar_innodb_flush_log_at_trx_commit">
             MySQL documentation</a>.</td>
      </tr>
     <tr>
@@ -101,7 +101,7 @@ to all service plans:
         <td>
           This setting defines the method used to flush data to InnoDB data and log files. <br>
           For more information, see the
-          <a href="https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_flush_method">MySQL documentation</a>.
+          <a href="https://dev.mysql.com/doc/refman/8.0/en/innodb-parameters.html#sysvar_innodb_flush_method">MySQL documentation</a>.
     </tr>
     <tr>
         <td><strong>InnoDB Auto Increment Lock Mode</strong></td>
@@ -111,6 +111,8 @@ to all service plans:
             This setting uses the interleaved mode.
             This enables multiple statements to execute at the same time.
             There can be gaps in auto-incrementing columns.
+            For more information, see the
+            <a href="https://dev.mysql.com/doc/refman/8.0/en/innodb-parameters.html#sysvar_innodb_autoinc_lock_mode">MySQL documentation</a>.
         </td>
     </tr>
     <tr>
@@ -118,14 +120,20 @@ to all service plans:
         <td><code>innodb-buffer-pool-size</code></td>
         <td>50% of the available memory on each service instance</td>
         <td>This setting is dynamically configured to be 50% of the available memory on each
-            service instance.</td>
+            service instance.
+          For more information, see the
+          <a href="https://dev.mysql.com/doc/refman/8.0/en/innodb-parameters.html#sysvar_innodb_buffer_pool_size">MySQL documentation</a>.
+        </td>
     </tr>
      <tr>
         <td><strong>InnoDB Log Buffer Size</strong></td>
         <td><code>innodb-log-buffer-size</code></td>
         <td>32&nbsp;MB</td>
         <td>This setting defaults to 32&nbsp;MB to avoid excessive disk I/O when
-            issuing large transactions.</td>
+            issuing large transactions.
+          For more information, see the
+          <a href="https://dev.mysql.com/doc/refman/8.0/en/innodb-parameters.html#sysvar_innodb_log_buffer_size">MySQL documentation</a>.
+        </td>
     </tr>
     <tr>
         <td><strong>Log Bin Trust Function Creators</strong></td>
@@ -134,7 +142,7 @@ to all service plans:
         <td>
             This setting relaxes constraints on how MySQL writes stored procedures
             to the binary log. <br>For more information, see the
-            <a href="https://dev.mysql.com/doc/refman/5.7/en/replication-options-binary-log.html#sysvar_log_bin_trust_function_creators">
+            <a href="https://dev.mysql.com/doc/refman/8.0/en/replication-options-binary-log.html#sysvar_log_bin_trust_function_creators">
                 MySQL documentation</a>.
         </td>
     </tr>
@@ -149,7 +157,7 @@ to all service plans:
             and permit developers to override the default when they create a
             service instance. <br>For more information about using lowercase
             table names, see the
-            <a href="https://dev.mysql.com/doc/refman/5.7/en/identifier-case-sensitivity.html">
+            <a href="https://dev.mysql.com/doc/refman/8.0/en/identifier-case-sensitivity.html">
                 MySQL documentation</a>.
         </td>
     </tr>
@@ -164,7 +172,7 @@ to all service plans:
         <td><code>max_binlog_size default</code></td>
         <td>~1/3 of the Space Limit for Binary Logs if <strong>Limit binary log disk use</strong> is selected.
         <td>For more information, see <a href="install-config.html#mysql">Configure MySQL</a> and
-            <a href="https://www.percona.com/doc/percona-server/5.7/flexibility/max_binlog_files.html">
+            <a href="https://docs.percona.com/percona-server/8.0/binlog-space.html">
             Percona documentation</a>.<br>
             If <strong>Limit binary log disk use</strong> is not selected, then no maximum is set.</td>
     </tr>
@@ -177,6 +185,8 @@ to all service plans:
             <%= vars.product_short %> uses user credentials, rather than hostnames, to authenticate access.
             Therefore, most deployments do not need reverse DNS lookups.<br><br>
             To activate reverse name resolution, deselect this option.
+            For more information, see the
+            <a href="https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_skip_name_resolve">MySQL documentation</a>.
         </td>
     </tr>
     <tr>
@@ -188,7 +198,7 @@ to all service plans:
             VMware recommends this security setting to prevent users from manipulating
             files on the server file system. <br>
             For more information, see
-            <a href="https://dev.mysql.com/doc/refman/5.7/en/security-against-attack.html">
+            <a href="https://dev.mysql.com/doc/refman/8.0/en/security-against-attack.html">
                 Making MySQL Secure Against Attackers</a>.
         </td>
     </tr>
@@ -198,7 +208,7 @@ to all service plans:
         <td>8192</td>
         <td>For information about changing this setting,
             see the
-            <a href="https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_table_definition_cache">
+            <a href="https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_table_definition_cache">
                 MySQL documentation</a>.
         </td>
     </tr>
@@ -224,17 +234,8 @@ and leader-follower plans use the server defaults listed in the following table:
         <td>5000 connections per service instance</td>
         <td>
             System processes count towards this limit.
-        </td>
-    </tr>
-    <tr>
-        <td><strong>MyISAM Recover Options</strong></td>
-        <td><code>myisam-recover-options</code></td>
-        <td>BACKUP, FORCE</td>
-        <td>
-            This setting enables <%= vars.product_short %> to recover from most MyISAM problems
-            without human intervention. <br>For more information, see the
-            <a href="https://dev.mysql.com/doc/refman/5.7/en/server-options.html#option_mysqld_myisam-recover-options">
-                MySQL documentation</a>.
+            For more information, see the
+            <a href="https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_max_connections">MySQL documentation</a>.
         </td>
     </tr>
     <tr>
@@ -244,13 +245,18 @@ and leader-follower plans use the server defaults listed in the following table:
         <td>
             <%= vars.product_short %> enables the event scheduler so users can create and use
             events in their dedicated service instances.
+            For more information, see the
+            <a href="https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_event_scheduler">MySQL documentation</a>.
         </td>
     </tr>
      <tr>
         <td><strong>InnoDB Log File Size</strong></td>
         <td><code>innodb-log-file-size</code></td>
         <td>256&nbsp;MB</td>
-        <td><%= vars.product_short %> clusters default to a log-file size of 256&nbsp;MB.</td>
+        <td><%= vars.product_short %> clusters default to a log-file size of 256&nbsp;MB.
+          For more information, see the
+          <a href="https://dev.mysql.com/doc/refman/8.0/en/innodb-parameters.html#sysvar_innodb_log_file_size">MySQL documentation</a>.
+        </td>
     </tr>
 
     <tr>
@@ -259,7 +265,7 @@ and leader-follower plans use the server defaults listed in the following table:
         <td><code>utf8_general_ci</code></td>
         <td>You can override this during a session.<br>For instructions about
           viewing available and default collations,
-          see the <a href="https://dev.mysql.com/doc/refman/5.7/en/charset-charsets.html">
+          see the <a href="https://dev.mysql.com/doc/refman/8.0/en/charset-charsets.html">
         MySQL documentation</a>.</td>
     </tr>
     <tr>
@@ -268,7 +274,7 @@ and leader-follower plans use the server defaults listed in the following table:
         <td><code>ON</code></td>
         <td> When enabled, relay log recovery happens automatically after server startup.<br>
           For more information, see the
-        <a href="https://dev.mysql.com/doc/refman/5.7/en/replication-options-replica.html#sysvar_relay_log_recovery">MySQL documentation</a>.</td>
+        <a href="https://dev.mysql.com/doc/refman/8.0/en/replication-options-replica.html#sysvar_relay_log_recovery">MySQL documentation</a>.</td>
     </tr>
 </table>
 
@@ -293,17 +299,8 @@ HA cluster plans use the server defaults listed in the following table:
         <td>5000 connections per service instance</td>
         <td>
             System processes count towards this limit.
-        </td>
-    </tr>
-    <tr>
-        <td><strong>MyISAM Recover Options</strong></td>
-        <td><code>myisam-recover-options</code></td>
-        <td>OFF</td>
-        <td>
-            This setting enables <%= vars.product_short %> to recover from most MyISAM problems
-            without human intervention. <br>For more information, see the
-            <a href="https://dev.mysql.com/doc/refman/5.7/en/server-options.html#option_mysqld_myisam-recover-options">
-                MySQL documentation</a>.
+            For more information, see the
+            <a href="https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_max_connections">MySQL documentation</a>.
         </td>
     </tr>
     <tr>
@@ -313,20 +310,25 @@ HA cluster plans use the server defaults listed in the following table:
         <td>
             <%= vars.product_short %> enables the event scheduler so users can create and use
             events in their dedicated service instances.
+            For more information, see the
+            <a href="https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_event_scheduler">MySQL documentation</a>.
         </td>
     </tr>
      <tr>
         <td><strong>InnoDB Log File Size</strong></td>
         <td><code>innodb-log-file-size</code></td>
         <td>1024&nbsp;MB</td>
-        <td><%= vars.product_short %> clusters default to a log-file size of 256&nbsp;MB.</td>
+        <td><%= vars.product_short %> clusters default to a log-file size of 256&nbsp;MB.
+          For more information, see the
+          <a href="https://dev.mysql.com/doc/refman/8.0/en/innodb-parameters.html#sysvar_innodb_log_file_size">MySQL documentation</a>.
+        </td>
     </tr>
     <tr>
         <td><strong>Collation Server</strong></td>
         <td><code>collation-server</code></td>
         <td><code>utf8_unicode_ci</code></td>
         <td>You can override this during a session. <br>For instructions about
-          viewing available and default collations, see the <a href="https://dev.mysql.com/doc/refman/5.7/en/charset-charsets.html">
+          viewing available and default collations, see the <a href="https://dev.mysql.com/doc/refman/8.0/en/charset-charsets.html">
         MySQL documentation</a>.</td>
     </tr>
     <tr>
@@ -335,7 +337,7 @@ HA cluster plans use the server defaults listed in the following table:
         <td><code>ON</code></td>
         <td> When enabled, relay log recovery happens automatically after server startup.<br>
           For more information, see the
-        <a href="https://dev.mysql.com/doc/refman/5.7/en/replication-options-replica.html#sysvar_relay_log_recovery">MySQL documentation</a>.</td>
+        <a href="https://dev.mysql.com/doc/refman/8.0/en/replication-options-replica.html#sysvar_relay_log_recovery">MySQL documentation</a>.</td>
     </tr>
 </table>
 
@@ -359,17 +361,8 @@ In addition to the server default settings that are common to all plans,
         <td>5000 connections per service instance</td>
         <td>
             System processes count towards this limit.
-        </td>
-    </tr>
-    <tr>
-        <td><strong>MyISAM Recover Options</strong></td>
-        <td><code>myisam-recover-options</code></td>
-        <td>OFF</td>
-        <td>
-            This setting activates <%= vars.product_short %> to recover from most MyISAM problems
-            without human intervention.<br>For more information, see the
-            <a href="https://dev.mysql.com/doc/refman/5.7/en/server-options.html#option_mysqld_myisam-recover-options">
-                MySQL documentation</a>.
+            For more information, see the
+            <a href="https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_max_connections">MySQL documentation</a>.
         </td>
     </tr>
     <tr>
@@ -379,13 +372,18 @@ In addition to the server default settings that are common to all plans,
         <td>
             <%= vars.product_short %> activates the event scheduler so users can create and use
             events in their dedicated service instances.
+            For more information, see the
+            <a href="https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_event_scheduler">MySQL documentation</a>.
         </td>
     </tr>
      <tr>
         <td><strong>InnoDB Log File Size</strong></td>
         <td><code>innodb-log-file-size</code></td>
         <td>1024&nbsp;MB</td>
-        <td><%= vars.product_short %> clusters default to a log-file size of 256&nbsp;MB.</td>
+        <td><%= vars.product_short %> clusters default to a log-file size of 256&nbsp;MB.
+          For more information, see the
+          <a href="https://dev.mysql.com/doc/refman/8.0/en/innodb-parameters.html#sysvar_innodb_log_file_size">MySQL documentation</a>.
+        </td>
     </tr>
 
     <tr>
@@ -394,7 +392,7 @@ In addition to the server default settings that are common to all plans,
         <td><code>utf8_unicode_ci</code></td>
         <td>You can override this setting during a session.<br>
           For instructions about
-          viewing available and default collations, see the <a href="https://dev.mysql.com/doc/refman/5.7/en/charset-charsets.html">
+          viewing available and default collations, see the <a href="https://dev.mysql.com/doc/refman/8.0/en/charset-charsets.html">
         MySQL documentation</a>.</td>
     </tr>
     <tr>
@@ -403,6 +401,6 @@ In addition to the server default settings that are common to all plans,
         <td><code>OFF</code></td>
         <td> When enabled, relay log recovery happens automatically after server startup.<br>
           For more information, see the
-        <a href="https://dev.mysql.com/doc/refman/5.7/en/replication-options-replica.html#sysvar_relay_log_recovery">MySQL documentation</a>.</td>
+        <a href="https://dev.mysql.com/doc/refman/8.0/en/replication-options-replica.html#sysvar_relay_log_recovery">MySQL documentation</a>.</td>
     </tr>
 </table>

--- a/server-defaults.html.md.erb
+++ b/server-defaults.html.md.erb
@@ -197,9 +197,9 @@ to all service plans:
             <%= vars.product_short %> is configured to prevent the use of symlinks to tables.
             VMware recommends this security setting to prevent users from manipulating
             files on the server file system. <br>
-            For more information, see
+            For more information, see the
             <a href="https://dev.mysql.com/doc/refman/8.0/en/security-against-attack.html">
-                Making MySQL Secure Against Attackers</a>.
+                MySQL documentation</a>.
         </td>
     </tr>
      <tr>

--- a/upgrade.html.md.erb
+++ b/upgrade.html.md.erb
@@ -51,6 +51,13 @@ By default, the `upgrade-all-service-instances` errand runs after each upgrade.
 For more information, see
 [About individual service instance upgrades](#individual-upgrades).
 
+>**Important**
+> As of <%= vars.product_short %> v3.2.0, only MySQL 8.0 is supported. When upgrading any plans _previously configured_
+> with "MySQL Default Version" set to "5.7" must be updated to specify "8.0".  On upgrade, all previously created
+> MySQL v5.7 service instance will be updated to MySQL v8.0 when either the platform operator runs the
+> [upgrade-all-service-instances](./errands.html#upgrade-all-service-instances) errand or the developer
+> [individually upgrades a service instance](./use.html#upgrade-an-individual-service-instance) via the cf cli.
+
 1. Go to **<%= vars.ops_manager %> Dashboard** > **Review Pending Changes**.
 For more information about this <%= vars.ops_manager %> page,
 see [Reviewing pending product changes](https://docs.vmware.com/en/VMware-Tanzu-Operations-Manager/3.0/vmware-tanzu-ops-manager/install-review-pending-changes.html).
@@ -90,9 +97,10 @@ An operator updates a stemcell version or their version of <%= vars.product_shor
 ### <a id='change-plan'></a>Plan change
 
 A developer changes their service instance to provide a different service plan, using `cf update-service` or Apps Manager.
-This process is used to update Service Instances from Percona 5.7 to Percona 8.0. For example
+
+ For example
 ```
-cf update-service SERVICE-INSTANCE -p PLAN-WITH-8.0
+cf update-service SERVICE-INSTANCE -p NEW-PLAN
 ```
 
 - <strong>Impact:</strong> Apps lose access to the MySQL service while <%= vars.ops_manager %>

--- a/upgrade.html.md.erb
+++ b/upgrade.html.md.erb
@@ -52,11 +52,12 @@ For more information, see
 [About individual service instance upgrades](#individual-upgrades).
 
 >**Important**
-> As of <%= vars.product_short %> v3.2.0, only MySQL 8.0 is supported. When upgrading any plans _previously configured_
-> with "MySQL Default Version" set to "5.7" must be updated to specify "8.0".  On upgrade, all previously created
-> MySQL v5.7 service instance will be updated to MySQL v8.0 when either the platform operator runs the
-> [upgrade-all-service-instances](./errands.html#upgrade-all-service-instances) errand or the developer
-> [individually upgrades a service instance](./use.html#upgrade-an-individual-service-instance) via the cf cli.
+> As of <%= vars.product_short %> v3.2.0, only MySQL 8.0 is supported. When upgrading, you must update any plans
+> _previously configured_ with a "MySQL Default Version" of "5.7", and specify "8.0". On upgrade, all previously
+> created MySQL v5.7 service instances are updated to MySQL v8.0, either when the platform operator runs the
+> [upgrade-all-service-instances](./errands.html#upgrade-all-service-instances) errand or when the developer
+> [individually upgrades a service instance](./use.html#upgrade-an-individual-service-instance) using the cf
+> CLI.
 
 1. Go to **<%= vars.ops_manager %> Dashboard** > **Review Pending Changes**.
 For more information about this <%= vars.ops_manager %> page,
@@ -98,7 +99,8 @@ An operator updates a stemcell version or their version of <%= vars.product_shor
 
 A developer changes their service instance to provide a different service plan, using `cf update-service` or Apps Manager.
 
- For example
+ For example:
+
 ```
 cf update-service SERVICE-INSTANCE -p NEW-PLAN
 ```

--- a/use.html.md.erb
+++ b/use.html.md.erb
@@ -429,14 +429,16 @@ To upgrade a single service instance:
 
 ####<a id="upgrade-mysql-8-0"></a> Upgrade a service instance to MySQL 8.0
 
-As of <%= vars.product_short %> v3.2, only MySQL 8.0 is supported.  If you created a service instance under a previous
-version of <%= vars.product_short %> then upgrading the service instance will force an upgrade to MySQL 8.0.
+As of <%= vars.product_short %> v3.2, only MySQL 8.0 is supported. If you created a service instance using a previous
+version of <%= vars.product_short %>, then upgrading the service instance will force an upgrade to MySQL 8.0.
 
-A service instance may be upgraded by running:
+To upgrade a service instance, run the following command:
 
   ```
   cf update-service SERVICE-INSTANCE-NAME --upgrade
   ```
+
+Where `SERVICE-INSTANCE-NAME` is the name of the service instance to upgrade.
 
 ###<a id="share"></a> Share service instances
 

--- a/use.html.md.erb
+++ b/use.html.md.erb
@@ -429,23 +429,13 @@ To upgrade a single service instance:
 
 ####<a id="upgrade-mysql-8-0"></a> Upgrade a service instance to MySQL 8.0
 
-When you upgrade a service instance using the `cf update-service` command with the
-`--upgrade` flag, the service instance continues to use MySQL 5.7. To upgrade a service
-instance to use MySQL 8.0, you have two options:
+As of <%= vars.product_short %> v3.2, only MySQL 8.0 is supported.  If you created a service instance under a previous
+version of <%= vars.product_short %> then upgrading the service instance will force an upgrade to MySQL 8.0.
 
-1. If you have configured the service plan used by your service instance to use
-MySQL 8.0, run the `cf update-service` command with the `-p` flag and specify the
-existing service plan used by the service instance:
+A service instance may be upgraded by running:
 
   ```
-  cf update-service SERVICE-INSTANCE-NAME -p my-existing-plan
-  ```
-1. If the service plan used by your service instance is still configured to use MySQL 5.7,
-run the `cf-update-service` command with the `-p` flag and specify a service plan
-that is configured to use MySQL 8.0:
-
-  ```
-  cf update-service SERVICE-INSTANCE-NAME -p new-8-0-plan
+  cf update-service SERVICE-INSTANCE-NAME --upgrade
   ```
 
 ###<a id="share"></a> Share service instances


### PR DESCRIPTION
- Added an initial release note about the major breaking change related to removing MySQL 5.7 support.

  This is a work-in-progress.  The platform engineer needs to more clearly be informed about the implications here related to updating any _old_ 5.7 based plans to 8.0 and verifying that application developers are ready for this 5.7 to 8.0 transition.

- Went through and identified links to mysql 5.7 docs and updated with links to 8.0.  These links should be correct as these pages were visiting this morning (2024-01-29).

- Updated backup metadata to better reflect the structure for a MySQL 8.0 based backup

- Removed obsolete references to "myisam-recover-options" for various topologies.  This MySQL server option has not been used in the product for a number of years and was merely misleading.

- Updated the docs on the "wsrep_applier_threads" while in the area to note the current tile behavior of scaling this value to the number of vCPUs rather than a hardcoded default.

wip because:
- Ensure better verbiage for the breaking change in this tile version with respect to mysql 5.7 users.

[#186781238](https://www.pivotaltracker.com/story/show/186781238)

Which other branches should this be merged with (if any)?
