### PR TITLE
Fixes typo that is a mix of markdown and HTML

### DIFF
--- a/about-migrate.html.md.erb
+++ b/about-migrate.html.md.erb
@@ -154,12 +154,8 @@ For instructions about using the `update-service` command, see
 
 ## <a id='unsupported'></a>Omitted data
 
-<p class="note important">
-<span class="note__title"> Important</span> The <code>migrate</code> command does not migrate all stored programs.
-The command only migrates views and does not migrate triggers, routines, or events.
-To manually migrate triggers, routines,	or events,
-contact <a href="https://www.vmware.com/support/services.html">VMware Support</a>.
-</p>
+>**Important**
+>The `migrate` command does not migrate all stored programs. The command only migrates views and does not migrate triggers, routines, or events. To manually migrate triggers, routines, or events, contact [VMware Tanzu Support](https://tanzu.vmware.com/support).
 
 The `migrate` command skips the following system schemas:
 

--- a/about-migrate.html.md.erb
+++ b/about-migrate.html.md.erb
@@ -158,7 +158,7 @@ For instructions about using the `update-service` command, see
 <span class="note__title"> Important</span> The <code>migrate</code> command does not migrate all stored programs.
 The command only migrates views and does not migrate triggers, routines, or events.
 To manually migrate triggers, routines,	or events,
-contact [VMware Support](https://www.vmware.com/support/services.html)</a>.
+contact <a href="https://www.vmware.com/support/services.html">VMware Support</a>.
 </p>
 
 The `migrate` command skips the following system schemas:


### PR DESCRIPTION
Authored-by: Ryan Wittrup <rwittrup@vmware.com>

Which other branches should this be merged with (if any)?
3.1, 2.10

For some reason, 3.0 is rendering properly