### PR TITLE
call out cron schedule bug fix

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -37,6 +37,9 @@ This release includes the following changes:
 
 + A number of high and critical CVEs were addressed by updating the components to the latest version.
 + MySQL service instances can automatically recover from an unexpected reboot
++ Fixed an issue where certain configurations of the backup Cron schedule could cause an error updating the service
+instance and `cf update-service` would fail with `The service broker has been updated, and this service instance is out of date`
+
 
 ### Compatibility
 


### PR DESCRIPTION
This bug could cause cf update-service to fail with certain configurations of a service instance cron schedule.

See [this internal KB article](https://pivotal.lightning.force.com/lightning/r/KnowledgeArticle__kav/ka08X000000cdcjQAA/view) for related context.

[#187486114](https://www.pivotaltracker.com/story/show/187486114)

> Which other branches should this be merged with (if any)?  

Just v2.10 for now.  This will apply to all supported versions of MySQL, but we will submit further PRs for those releases.